### PR TITLE
feat: add intentional usage timers

### DIFF
--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -15,12 +15,30 @@ Keep the useful parts of social networks while giving every feed a real end.
 
 1. The user opens a supported social-network page.
 2. A configurable opening pause interrupts automatic entry.
-3. Dopamine Fast removes promoted and suggested content.
-4. The first 20 top-level post elements remain visible.
-5. The native feed is covered by an end-of-batch barrier after the twentieth
+3. The user chooses how many minutes the session should last.
+4. A floating countdown remains visible while the supported feed is active.
+5. Dopamine Fast removes promoted and suggested content.
+6. The first 20 top-level post elements remain visible.
+7. The native feed is covered by an end-of-batch barrier after the twentieth
    post.
-6. The user can leave or deliberately unlock 10 additional posts.
-7. A daily hard limit stops further unlocks.
+8. The user can leave or deliberately unlock 10 additional posts.
+9. Daily hard limits for both time and posts stop further use.
+
+## Time budgets
+
+- Before entry, the user selects an intentional session duration.
+- The configured default is 10 minutes and can be adjusted from 1 to 60
+  minutes at entry.
+- A compact floating counter shows the planned session time and the remaining
+  daily time for the current network.
+- Time advances only while the tab is visible.
+- When planned time ends, the user can leave or deliberately plan another
+  block.
+- A separate daily limit applies to each supported network. It persists across
+  reloads and sessions, resets on the next local calendar day and has no
+  in-page unlock.
+- The effective ceiling is fixed for the day. Configuration changes apply on
+  the next local calendar day, and the settings page cannot reset elapsed time.
 
 ## Unlock flow
 
@@ -80,6 +98,7 @@ The answers are stored only as aggregate local counts and are never transmitted.
 ## Privacy and permissions
 
 - Local storage only.
+- Time counters store elapsed seconds per network, never browsing content.
 - No backend or analytics.
 - No cookie permission.
 - Host access limited to supported domains.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The MVP targets Firefox for Android and supports Reddit, X/Twitter and
 Instagram. It works on top of the websites you already use:
 
 - pauses before opening a supported feed;
+- asks how long you intend to stay and keeps that countdown visible;
+- enforces a separate daily time ceiling for each network;
 - hides best-effort suggested and promoted surfaces;
 - disables media autoplay;
 - reveals posts in finite batches;
@@ -62,6 +64,8 @@ Mozilla's Firefox Android extension development workflow.
 ```text
 entrypoints/content.ts
   ├─ opening pause
+  ├─ intentional session timer
+  ├─ hard daily time ceiling
   ├─ route activation
   └─ FeedLimiter
        ├─ platform selectors
@@ -77,10 +81,15 @@ lib/
   ├─ storage.ts
   ├─ platforms.ts
   ├─ feed-limiter.ts
+  ├─ usage-session.ts
   └─ intervention-ui.ts
 ```
 
-All preferences and daily counters use browser extension local storage.
+All preferences and daily counters use browser extension local storage. Usage
+time advances only while the supported feed tab is visible. The planned
+session can be renewed deliberately; the per-network daily ceiling has no
+in-page override or reset. Changes to that ceiling take effect on the next
+local calendar day.
 
 ## Releases and dependency updates
 

--- a/assets/content.css
+++ b/assets/content.css
@@ -14,8 +14,16 @@
   line-height: 1.45;
 }
 
-.df-root[data-visible="false"] {
+.df-overlay-slot:empty,
+.df-timer-slot:empty {
   display: none;
+}
+
+.df-timer-slot {
+  position: fixed;
+  z-index: 2147483646;
+  right: max(12px, env(safe-area-inset-right));
+  bottom: max(72px, calc(env(safe-area-inset-bottom) + 64px));
 }
 
 .df-backdrop {
@@ -96,6 +104,46 @@
   font-family: "Iowan Old Style", "Palatino Linotype", serif;
   font-size: 42px;
   font-variant-numeric: tabular-nums;
+}
+
+.df-time-choice {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  max-width: 390px;
+  margin: 20px auto 0;
+  padding: 14px 16px;
+  border: 1px solid var(--df-line);
+  background: rgba(255, 255, 255, 0.34);
+  color: var(--df-ink);
+  font-size: 13px;
+  font-weight: 800;
+  text-align: left;
+}
+
+.df-time-choice output {
+  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
+  font-size: 20px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.df-time-choice input {
+  grid-column: 1 / -1;
+  width: 100%;
+  accent-color: var(--df-ink);
+}
+
+.df-hard-limit-note {
+  max-width: 390px;
+  margin: 12px auto 0;
+  color: var(--df-muted);
+  font-size: 12px;
+  text-align: left;
+}
+
+.df-hard-limit-note strong {
+  color: var(--df-ink);
 }
 
 .df-rule {
@@ -199,6 +247,95 @@
     );
 }
 
+.df-pause-mark--centered {
+  margin: 8px auto 28px;
+}
+
+.df-lock-mark {
+  width: 54px;
+  height: 44px;
+  margin-bottom: 28px;
+  border: 7px solid var(--df-ink);
+  border-top: 0;
+  background: var(--df-accent);
+  box-sizing: border-box;
+}
+
+.df-lock-mark::before {
+  display: block;
+  width: 28px;
+  height: 24px;
+  margin: -20px auto 0;
+  border: 6px solid var(--df-ink);
+  border-bottom: 0;
+  border-radius: 18px 18px 0 0;
+  content: "";
+  box-sizing: border-box;
+}
+
+.df-usage-timer {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  min-width: 142px;
+  align-items: center;
+  padding: 9px 12px;
+  border: 1px solid rgba(243, 239, 228, 0.5);
+  border-radius: 2px;
+  color: var(--df-paper);
+  background: rgba(23, 32, 24, 0.94);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.28);
+  font: inherit;
+  text-align: left;
+  backdrop-filter: blur(12px);
+  cursor: pointer;
+}
+
+.df-usage-timer__pulse {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--df-accent);
+  box-shadow: 0 0 0 4px rgba(204, 255, 0, 0.14);
+}
+
+.df-usage-timer__copy {
+  display: grid;
+  line-height: 1.05;
+}
+
+.df-usage-timer strong {
+  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
+  font-size: 22px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+}
+
+.df-usage-timer small {
+  margin-top: 3px;
+  color: rgba(243, 239, 228, 0.68);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.df-usage-timer[data-urgent="true"] {
+  border-color: var(--df-ink);
+  color: var(--df-ink);
+  background: var(--df-accent);
+}
+
+.df-usage-timer[data-urgent="true"] small {
+  color: rgba(23, 32, 24, 0.68);
+}
+
+.df-usage-timer[data-urgent="true"] .df-usage-timer__pulse {
+  background: var(--df-ink);
+  animation: df-timer-pulse 1s ease-in-out infinite;
+}
+
 .df-hold {
   position: relative;
   isolation: isolate;
@@ -247,6 +384,13 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
+@keyframes df-timer-pulse {
+  50% {
+    opacity: 0.35;
+    transform: scale(0.72);
+  }
+}
+
 @media (min-width: 680px) {
   .df-backdrop {
     align-items: center;
@@ -260,7 +404,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .df-backdrop,
-  .df-card {
+  .df-card,
+  .df-usage-timer__pulse {
     animation: none;
   }
 }

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -1,8 +1,15 @@
 import "../assets/content.css";
 import { FeedLimiter } from "../lib/feed-limiter";
 import { InterventionUi } from "../lib/intervention-ui";
+import { availableUsageSeconds } from "../lib/models";
 import { getPlatformAdapter } from "../lib/platforms";
-import { getSettings, reserveAllowance, settingsItem } from "../lib/storage";
+import {
+  getDailyUsageState,
+  getSettings,
+  reserveAllowance,
+  settingsItem,
+} from "../lib/storage";
+import { UsageSession } from "../lib/usage-session";
 
 export default defineContentScript({
   matches: [
@@ -37,12 +44,11 @@ export default defineContentScript({
       onMount(container) {
         const root = document.createElement("div");
         root.className = "df-root";
-        root.dataset.visible = "false";
         container.append(root);
         return new InterventionUi(root);
       },
       onRemove(ui) {
-        ui?.hide();
+        ui?.hideAll();
       },
     });
     shadowUi.mount();
@@ -51,6 +57,7 @@ export default defineContentScript({
     if (!intervention) return;
 
     let limiter: FeedLimiter | undefined;
+    let usageSession: UsageSession | undefined;
     let currentUrl = "";
     let activationId = 0;
 
@@ -58,7 +65,11 @@ export default defineContentScript({
       const thisActivation = ++activationId;
       limiter?.destroy();
       limiter = undefined;
-      intervention.hide();
+      const previousUsageSession = usageSession;
+      usageSession = undefined;
+      await previousUsageSession?.destroy();
+      if (thisActivation !== activationId) return;
+      intervention.hideAll();
 
       const url = new URL(location.href);
       const settings = await getSettings();
@@ -70,11 +81,26 @@ export default defineContentScript({
         return;
       }
 
-      await intervention.showOpening(
-        adapter.label,
-        settings.openingDelaySeconds,
+      const usageState = await getDailyUsageState();
+      const availableSeconds = availableUsageSeconds(
+        settings,
+        usageState,
+        adapter.id,
       );
       if (thisActivation !== activationId) return;
+      if (availableSeconds <= 0) {
+        intervention.showHardLimitReached(adapter.label);
+        return;
+      }
+
+      const plannedSeconds = await intervention.showOpening({
+        platformLabel: adapter.label,
+        delaySeconds: settings.openingDelaySeconds,
+        defaultSessionMinutes: settings.sessionDurationMinutes,
+        availableSeconds,
+      });
+      if (thisActivation !== activationId) return;
+      if (plannedSeconds <= 0) return;
 
       const initialAllowance = await reserveAllowance(
         adapter.id,
@@ -89,6 +115,44 @@ export default defineContentScript({
         initialAllowance,
       );
       limiter.start();
+
+      const session = new UsageSession({
+        platform: adapter.id,
+        platformLabel: adapter.label,
+        plannedSeconds,
+        availableSeconds,
+        ui: intervention,
+        onPlannedTimeElapsed(remainingSeconds) {
+          void (async () => {
+            const extensionSeconds = await intervention.showSessionEnded({
+              platformLabel: adapter.label,
+              defaultSessionMinutes: settings.sessionDurationMinutes,
+              availableSeconds: remainingSeconds,
+            });
+            if (
+              thisActivation !== activationId ||
+              usageSession !== session
+            ) {
+              return;
+            }
+            session.extend(extensionSeconds);
+            limiter?.restoreEndOfBatch();
+          })();
+        },
+        onHardLimitReached() {
+          if (
+            thisActivation !== activationId ||
+            usageSession !== session
+          ) {
+            return;
+          }
+          limiter?.destroy();
+          limiter = undefined;
+          intervention.showHardLimitReached(adapter.label);
+        },
+      });
+      usageSession = session;
+      session.start();
     };
 
     currentUrl = location.href;
@@ -108,6 +172,7 @@ export default defineContentScript({
       window.clearInterval(navigationTimer);
       unwatchSettings();
       limiter?.destroy();
+      void usageSession?.destroy();
       shadowUi.remove();
     });
   },

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -32,6 +32,45 @@
         <section class="panel">
           <div class="section-number">01</div>
           <div class="section-heading">
+            <h2>Tiempo consciente</h2>
+            <p>
+              Elige una intención por sesión y un techo diario que no se puede
+              desbloquear.
+            </p>
+          </div>
+
+          <div class="number-grid number-grid--two">
+            <label class="number-field">
+              <span>Sesión sugerida</span>
+              <input
+                id="session-duration"
+                name="sessionDurationMinutes"
+                type="number"
+                min="1"
+                max="60"
+                step="1"
+              />
+              <small>minutos, ajustables al entrar</small>
+            </label>
+
+            <label class="number-field">
+              <span>Máximo diario por red</span>
+              <input
+                id="daily-usage-limit"
+                name="dailyUsageLimitMinutes"
+                type="number"
+                min="5"
+                max="240"
+                step="5"
+              />
+              <small>minutos, fijo hasta mañana</small>
+            </label>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="section-number">02</div>
+          <div class="section-heading">
             <h2>Ritmo de entrada</h2>
             <p>Introduce una pausa antes de abrir un feed.</p>
           </div>
@@ -64,7 +103,7 @@
         </section>
 
         <section class="panel">
-          <div class="section-number">02</div>
+          <div class="section-number">03</div>
           <div class="section-heading">
             <h2>Tamaño del feed</h2>
             <p>Cada lote termina de verdad. Tú decides si abres otro.</p>
@@ -113,7 +152,7 @@
         </section>
 
         <section class="panel">
-          <div class="section-number">03</div>
+          <div class="section-number">04</div>
           <div class="section-heading">
             <h2>Fricción</h2>
             <p>Cuánto cuesta elegir conscientemente otro lote.</p>
@@ -158,7 +197,7 @@
         </section>
 
         <section class="panel">
-          <div class="section-number">04</div>
+          <div class="section-number">05</div>
           <div class="section-heading">
             <h2>Redes y ruido</h2>
             <p>La detección es inicial: afinaremos selectores al probarla.</p>
@@ -177,7 +216,7 @@
           <p id="save-status" role="status" aria-live="polite"></p>
           <div>
             <button class="button button--quiet" id="reset-day" type="button">
-              Reiniciar contador de hoy
+              Reiniciar publicaciones de hoy
             </button>
             <button class="button button--primary" type="submit">
               Guardar cambios

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -20,6 +20,8 @@ const controls = {
   openingDelayOutput: requiredElement<HTMLOutputElement>(
     "#opening-delay-output",
   ),
+  sessionDuration: requiredElement<HTMLInputElement>("#session-duration"),
+  dailyUsageLimit: requiredElement<HTMLInputElement>("#daily-usage-limit"),
   unlockDelay: requiredElement<HTMLInputElement>("#unlock-delay"),
   unlockDelayOutput:
     requiredElement<HTMLOutputElement>("#unlock-delay-output"),
@@ -51,6 +53,8 @@ function updateOutputs(): void {
 function render(settings: Settings): void {
   controls.enabled.checked = settings.enabled;
   controls.openingDelay.value = String(settings.openingDelaySeconds);
+  controls.sessionDuration.value = String(settings.sessionDurationMinutes);
+  controls.dailyUsageLimit.value = String(settings.dailyUsageLimitMinutes);
   controls.unlockDelay.value = String(settings.unlockDelaySeconds);
   controls.batchSize.value = String(settings.batchSize);
   controls.unlockBatchSize.value = String(settings.unlockBatchSize);
@@ -76,6 +80,8 @@ function readSettings(): Settings {
     enabled: controls.enabled.checked,
     mode: mode as GuardMode,
     openingDelaySeconds: Number(controls.openingDelay.value),
+    sessionDurationMinutes: Number(controls.sessionDuration.value),
+    dailyUsageLimitMinutes: Number(controls.dailyUsageLimit.value),
     unlockDelaySeconds: Number(controls.unlockDelay.value),
     batchSize: Number(controls.batchSize.value),
     unlockBatchSize: Number(controls.unlockBatchSize.value),
@@ -98,7 +104,8 @@ function readSettings(): Settings {
 form.addEventListener("submit", async (event) => {
   event.preventDefault();
   await saveSettings(readSettings());
-  status.textContent = "Guardado en este navegador.";
+  status.textContent =
+    "Guardado. Si hoy ya usaste una red, su nuevo techo se aplica mañana.";
   window.setTimeout(() => {
     status.textContent = "";
   }, 2400);
@@ -108,7 +115,7 @@ requiredElement<HTMLButtonElement>("#reset-day").addEventListener(
   "click",
   async () => {
     await resetDailyState();
-    status.textContent = "El contador de hoy vuelve a cero.";
+    status.textContent = "El contador de publicaciones vuelve a cero.";
   },
 );
 

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -311,6 +311,10 @@ input {
     grid-template-columns: repeat(3, 1fr);
   }
 
+  .number-grid--two {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
   .number-field {
     grid-template-columns: 1fr;
   }

--- a/lib/feed-limiter.ts
+++ b/lib/feed-limiter.ts
@@ -61,6 +61,12 @@ export class FeedLimiter {
     this.ui.hide();
   }
 
+  restoreEndOfBatch(): void {
+    if (!this.endVisible || this.destroyed) return;
+    this.endVisible = false;
+    void this.presentEndOfBatch();
+  }
+
   private scheduleProcess(): void {
     if (this.destroyed || this.processingTimer) return;
     this.processingTimer = window.setTimeout(() => {

--- a/lib/intervention-ui.ts
+++ b/lib/intervention-ui.ts
@@ -8,6 +8,25 @@ export interface EndOfBatchOptions {
   onUnlock(): Promise<number>;
 }
 
+export interface OpeningOptions {
+  platformLabel: string;
+  delaySeconds: number;
+  defaultSessionMinutes: number;
+  availableSeconds: number;
+}
+
+export interface UsageTimerOptions {
+  platformLabel: string;
+  plannedSeconds: number;
+  availableSeconds: number;
+}
+
+export interface SessionEndedOptions {
+  platformLabel: string;
+  defaultSessionMinutes: number;
+  availableSeconds: number;
+}
+
 const intentions = [
   ["specific", "Busco algo concreto"],
   ["reply", "Quiero responder o interactuar"],
@@ -17,47 +36,97 @@ const intentions = [
 
 export class InterventionUi {
   private readonly root: HTMLElement;
+  private readonly overlay: HTMLElement;
+  private readonly timer: HTMLElement;
   private previousHtmlOverflow = "";
   private previousBodyOverflow = "";
   private pageLocked = false;
+  private cancelPendingInteraction?: () => void;
 
   constructor(root: HTMLElement) {
     this.root = root;
+    this.overlay = document.createElement("div");
+    this.overlay.className = "df-overlay-slot";
+    this.timer = document.createElement("div");
+    this.timer.className = "df-timer-slot";
+    this.root.replaceChildren(this.overlay, this.timer);
   }
 
   hide(): void {
-    this.root.replaceChildren();
-    this.root.dataset.visible = "false";
+    const cancelPendingInteraction = this.cancelPendingInteraction;
+    this.cancelPendingInteraction = undefined;
+    cancelPendingInteraction?.();
+    this.overlay.replaceChildren();
     this.unlockPage();
   }
 
-  async showOpening(
-    platformLabel: string,
-    delaySeconds: number,
-  ): Promise<void> {
-    if (delaySeconds <= 0) return;
+  hideAll(): void {
+    this.hide();
+    this.hideUsageTimer();
+  }
 
+  showOpening(options: OpeningOptions): Promise<number> {
     this.lockPage();
-    this.root.dataset.visible = "true";
-    this.root.innerHTML = `
+    const maximumMinutes = Math.max(
+      1,
+      Math.min(60, Math.ceil(options.availableSeconds / 60)),
+    );
+    const defaultMinutes = Math.min(
+      options.defaultSessionMinutes,
+      maximumMinutes,
+    );
+    const defaultSessionLabel =
+      options.availableSeconds < 60 ? "<1 min" : `${defaultMinutes} min`;
+    this.overlay.innerHTML = `
       <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-opening-title">
         <article class="df-card df-card--opening">
           <p class="df-kicker">Una pausa antes de entrar</p>
-          <div class="df-countdown" aria-live="polite">${delaySeconds}</div>
-          <h1 id="df-opening-title">¿A qué vienes a ${platformLabel}?</h1>
-          <p class="df-copy">No tienes que responder. Solo deja que pase el impulso automático.</p>
+          ${
+            options.delaySeconds > 0
+              ? `<div class="df-countdown" aria-live="polite">${options.delaySeconds}</div>`
+              : `<div class="df-pause-mark df-pause-mark--centered" aria-hidden="true"></div>`
+          }
+          <h1 id="df-opening-title">¿Cuánto tiempo quieres dedicar a ${options.platformLabel}?</h1>
+          <p class="df-copy">
+            Elige ahora una sesión concreta. El contador seguirá visible mientras navegas.
+          </p>
+          <label class="df-time-choice">
+            <span>Esta sesión</span>
+            <output for="df-session-minutes">${defaultSessionLabel}</output>
+            <input
+              id="df-session-minutes"
+              type="range"
+              min="1"
+              max="${maximumMinutes}"
+              value="${defaultMinutes}"
+              step="1"
+              ${options.availableSeconds < 60 ? "disabled" : ""}
+            />
+          </label>
+          <p class="df-hard-limit-note">
+            Quedan <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong>
+            del límite diario de esta red.
+          </p>
           <div class="df-actions">
             <button class="df-button df-button--quiet" data-action="leave">Salir</button>
             <button class="df-button df-button--primary" data-action="continue" disabled>
-              Continuar en ${delaySeconds}s
+              ${
+                options.delaySeconds > 0
+                  ? `Continuar en ${options.delaySeconds}s`
+                  : `Entrar ${defaultSessionLabel}`
+              }
             </button>
           </div>
-          <button class="df-settings-link" data-action="settings">Ajustar esta pausa</button>
+          <button class="df-settings-link" data-action="settings">Ajustar tiempos y límites</button>
         </article>
       </section>
     `;
 
-    const countdown = this.requiredElement<HTMLElement>(".df-countdown");
+    const countdown = this.overlay.querySelector<HTMLElement>(".df-countdown");
+    const sessionInput =
+      this.requiredElement<HTMLInputElement>("#df-session-minutes");
+    const sessionOutput =
+      this.requiredElement<HTMLOutputElement>(".df-time-choice output");
     const continueButton =
       this.requiredElement<HTMLButtonElement>('[data-action="continue"]');
     const leaveButton =
@@ -70,32 +139,60 @@ export class InterventionUi {
       browser.runtime.openOptionsPage(),
     );
 
-    await new Promise<void>((resolve) => {
-      let remaining = delaySeconds;
-      const interval = window.setInterval(() => {
-        remaining -= 1;
-        countdown.textContent = String(Math.max(0, remaining));
-        continueButton.textContent =
-          remaining > 0 ? `Continuar en ${remaining}s` : "Entrar con intención";
+    sessionInput.addEventListener("input", () => {
+      const label =
+        options.availableSeconds < 60 ? "<1 min" : `${sessionInput.value} min`;
+      sessionOutput.value = label;
+      if (!continueButton.disabled) {
+        continueButton.textContent = `Entrar ${label}`;
+      }
+    });
 
-        if (remaining <= 0) {
-          window.clearInterval(interval);
-          continueButton.disabled = false;
-        }
-      }, 1000);
+    return new Promise<number>((resolve) => {
+      let remaining = options.delaySeconds;
+      let interval: number | undefined;
+      this.cancelPendingInteraction = () => {
+        if (interval !== undefined) window.clearInterval(interval);
+        resolve(0);
+      };
+      if (remaining <= 0) {
+        continueButton.disabled = false;
+      } else {
+        interval = window.setInterval(() => {
+          remaining -= 1;
+          if (countdown) countdown.textContent = String(Math.max(0, remaining));
+          continueButton.textContent =
+            remaining > 0
+              ? `Continuar en ${remaining}s`
+              : `Entrar ${
+                  options.availableSeconds < 60
+                    ? "<1 min"
+                    : `${sessionInput.value} min`
+                }`;
+
+          if (remaining <= 0) {
+            if (interval !== undefined) window.clearInterval(interval);
+            continueButton.disabled = false;
+          }
+        }, 1000);
+      }
 
       continueButton.addEventListener("click", () => {
-        window.clearInterval(interval);
+        if (interval !== undefined) window.clearInterval(interval);
+        const selectedSeconds = Math.min(
+          Number(sessionInput.value) * 60,
+          options.availableSeconds,
+        );
+        this.cancelPendingInteraction = undefined;
         this.hide();
-        resolve();
+        resolve(selectedSeconds);
       });
     });
   }
 
   showEndOfBatch(options: EndOfBatchOptions): void {
     this.lockPage();
-    this.root.dataset.visible = "true";
-    this.root.innerHTML = `
+    this.overlay.innerHTML = `
       <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-end-title">
         <article class="df-card">
           <div class="df-rule"></div>
@@ -123,9 +220,152 @@ export class InterventionUi {
       .addEventListener("click", () => history.back());
     this.requiredElement<HTMLButtonElement>('[data-action="settings"]')
       .addEventListener("click", () => browser.runtime.openOptionsPage());
-    this.root
+    this.overlay
       .querySelector<HTMLButtonElement>('[data-action="unlock"]')
       ?.addEventListener("click", () => this.showIntentionStep(options));
+  }
+
+  showSessionEnded(options: SessionEndedOptions): Promise<number> {
+    this.lockPage();
+    const maximumMinutes = Math.max(
+      1,
+      Math.min(60, Math.ceil(options.availableSeconds / 60)),
+    );
+    const defaultMinutes = Math.min(
+      options.defaultSessionMinutes,
+      maximumMinutes,
+    );
+    const defaultSessionLabel =
+      options.availableSeconds < 60 ? "<1 min" : `${defaultMinutes} min`;
+    this.overlay.innerHTML = `
+      <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-session-end-title">
+        <article class="df-card">
+          <div class="df-rule"></div>
+          <p class="df-kicker">Tiempo elegido completado</p>
+          <h1 id="df-session-end-title">Tu sesión ya terminó.</h1>
+          <p class="df-copy">
+            Elegiste parar aquí. Si todavía tienes un motivo concreto, puedes planear otro bloque.
+          </p>
+          <label class="df-time-choice">
+            <span>Nuevo bloque</span>
+            <output for="df-extra-minutes">${defaultSessionLabel}</output>
+            <input
+              id="df-extra-minutes"
+              type="range"
+              min="1"
+              max="${maximumMinutes}"
+              value="${defaultMinutes}"
+              step="1"
+              ${options.availableSeconds < 60 ? "disabled" : ""}
+            />
+          </label>
+          <p class="df-hard-limit-note">
+            El techo diario no se puede ampliar:
+            <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong> disponibles.
+          </p>
+          <div class="df-actions">
+            <button class="df-button df-button--primary" data-action="leave">Salir de ${options.platformLabel}</button>
+            <button class="df-button df-button--quiet" data-action="extend">Planear otro bloque</button>
+          </div>
+          <button class="df-settings-link" data-action="settings">Cambiar el valor predeterminado</button>
+        </article>
+      </section>
+    `;
+
+    const input = this.requiredElement<HTMLInputElement>("#df-extra-minutes");
+    const output =
+      this.requiredElement<HTMLOutputElement>(".df-time-choice output");
+    input.addEventListener("input", () => {
+      output.value =
+        options.availableSeconds < 60 ? "<1 min" : `${input.value} min`;
+    });
+    this.requiredElement<HTMLButtonElement>('[data-action="leave"]')
+      .addEventListener("click", () => history.back());
+    this.requiredElement<HTMLButtonElement>('[data-action="settings"]')
+      .addEventListener("click", () => browser.runtime.openOptionsPage());
+
+    return new Promise<number>((resolve) => {
+      this.cancelPendingInteraction = () => resolve(0);
+      this.requiredElement<HTMLButtonElement>('[data-action="extend"]')
+        .addEventListener("click", () => {
+          const selectedSeconds = Math.min(
+            Number(input.value) * 60,
+            options.availableSeconds,
+          );
+          this.cancelPendingInteraction = undefined;
+          this.hide();
+          resolve(selectedSeconds);
+        });
+    });
+  }
+
+  showHardLimitReached(platformLabel: string): void {
+    const cancelPendingInteraction = this.cancelPendingInteraction;
+    this.cancelPendingInteraction = undefined;
+    cancelPendingInteraction?.();
+    this.lockPage();
+    this.overlay.innerHTML = `
+      <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-hard-limit-title">
+        <article class="df-card">
+          <div class="df-lock-mark" aria-hidden="true"></div>
+          <p class="df-kicker">Límite diario completado</p>
+          <h1 id="df-hard-limit-title">${platformLabel} termina aquí por hoy.</h1>
+          <p class="df-copy">
+            Este límite no tiene desbloqueo. Volverá a estar disponible mañana.
+          </p>
+          <div class="df-actions df-actions--stack">
+            <button class="df-button df-button--primary" data-action="leave">Salir de ${platformLabel}</button>
+          </div>
+          <button class="df-settings-link" data-action="settings">Ver configuración</button>
+        </article>
+      </section>
+    `;
+
+    this.requiredElement<HTMLButtonElement>('[data-action="leave"]')
+      .addEventListener("click", () => history.back());
+    this.requiredElement<HTMLButtonElement>('[data-action="settings"]')
+      .addEventListener("click", () => browser.runtime.openOptionsPage());
+  }
+
+  showUsageTimer(options: UsageTimerOptions): void {
+    if (this.timer.childElementCount === 0) {
+      this.timer.innerHTML = `
+        <button class="df-usage-timer" type="button" title="Abrir los ajustes de Dopamine Fast">
+          <span class="df-usage-timer__pulse" aria-hidden="true"></span>
+          <span class="df-usage-timer__copy">
+            <strong data-timer="planned"></strong>
+            <small><span data-timer="platform"></span> · <span data-timer="daily"></span> hoy</small>
+          </span>
+        </button>
+      `;
+      this.timer
+        .querySelector<HTMLButtonElement>(".df-usage-timer")
+        ?.addEventListener("click", () => browser.runtime.openOptionsPage());
+    }
+
+    const timer = this.timer.querySelector<HTMLElement>(".df-usage-timer");
+    const planned =
+      this.timer.querySelector<HTMLElement>('[data-timer="planned"]');
+    const platform =
+      this.timer.querySelector<HTMLElement>('[data-timer="platform"]');
+    const daily = this.timer.querySelector<HTMLElement>('[data-timer="daily"]');
+    if (!timer || !planned || !platform || !daily) return;
+
+    planned.textContent = this.formatClock(options.plannedSeconds);
+    platform.textContent = options.platformLabel;
+    daily.textContent = this.formatFriendlyDuration(options.availableSeconds);
+    timer.dataset.urgent =
+      options.plannedSeconds <= 60 || options.availableSeconds <= 60
+        ? "true"
+        : "false";
+    timer.setAttribute(
+      "aria-label",
+      `${this.formatClock(options.plannedSeconds)} de sesión; ${this.formatFriendlyDuration(options.availableSeconds)} disponibles hoy en ${options.platformLabel}`,
+    );
+  }
+
+  hideUsageTimer(): void {
+    this.timer.replaceChildren();
   }
 
   private showIntentionStep(options: EndOfBatchOptions): void {
@@ -250,9 +490,25 @@ export class InterventionUi {
   }
 
   private requiredElement<T extends Element>(selector: string): T {
-    const element = this.root.querySelector<T>(selector);
+    const element = this.overlay.querySelector<T>(selector);
     if (!element) throw new Error(`Missing intervention UI element: ${selector}`);
     return element;
+  }
+
+  private formatClock(totalSeconds: number): string {
+    const safeSeconds = Math.max(0, Math.ceil(totalSeconds));
+    const minutes = Math.floor(safeSeconds / 60);
+    const seconds = safeSeconds % 60;
+    return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  }
+
+  private formatFriendlyDuration(totalSeconds: number): string {
+    const safeSeconds = Math.max(0, Math.ceil(totalSeconds));
+    if (safeSeconds < 60) return "<1 min";
+    const hours = Math.floor(safeSeconds / 3600);
+    const minutes = Math.ceil((safeSeconds % 3600) / 60);
+    if (hours === 0) return `${minutes} min`;
+    return minutes > 0 ? `${hours} h ${minutes} min` : `${hours} h`;
   }
 
   private lockPage(): void {

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -5,6 +5,8 @@ export interface Settings {
   enabled: boolean;
   mode: GuardMode;
   openingDelaySeconds: number;
+  sessionDurationMinutes: number;
+  dailyUsageLimitMinutes: number;
   batchSize: number;
   unlockBatchSize: number;
   dailyLimit: number;
@@ -22,10 +24,18 @@ export interface DailyState {
   unlocks: number;
 }
 
+export interface DailyUsageState {
+  date: string;
+  dailyLimitMinutes: number;
+  usedSecondsByPlatform: Record<PlatformId, number>;
+}
+
 export const DEFAULT_SETTINGS: Settings = {
   enabled: true,
   mode: "balanced",
   openingDelaySeconds: 5,
+  sessionDurationMinutes: 10,
+  dailyUsageLimitMinutes: 30,
   batchSize: 20,
   unlockBatchSize: 10,
   dailyLimit: 60,
@@ -57,6 +67,16 @@ export function sanitizeSettings(input: Partial<Settings>): Settings {
       input.openingDelaySeconds ?? DEFAULT_SETTINGS.openingDelaySeconds,
       0,
       60,
+    ),
+    sessionDurationMinutes: clampInteger(
+      input.sessionDurationMinutes ?? DEFAULT_SETTINGS.sessionDurationMinutes,
+      1,
+      60,
+    ),
+    dailyUsageLimitMinutes: clampInteger(
+      input.dailyUsageLimitMinutes ?? DEFAULT_SETTINGS.dailyUsageLimitMinutes,
+      5,
+      240,
     ),
     batchSize: clampInteger(
       input.batchSize ?? DEFAULT_SETTINGS.batchSize,
@@ -115,6 +135,53 @@ export function normalizeDailyState(
   date = new Date(),
 ): DailyState {
   return state?.date === localDateKey(date) ? state : emptyDailyState(date);
+}
+
+export function emptyDailyUsageState(
+  date = new Date(),
+  dailyLimitMinutes = 0,
+): DailyUsageState {
+  return {
+    date: localDateKey(date),
+    dailyLimitMinutes,
+    usedSecondsByPlatform: {
+      reddit: 0,
+      x: 0,
+      instagram: 0,
+    },
+  };
+}
+
+export function normalizeDailyUsageState(
+  state: DailyUsageState | null,
+  date = new Date(),
+  configuredLimitMinutes = DEFAULT_SETTINGS.dailyUsageLimitMinutes,
+): DailyUsageState {
+  if (state?.date !== localDateKey(date)) {
+    return emptyDailyUsageState(date, configuredLimitMinutes);
+  }
+
+  if (state.dailyLimitMinutes >= 5) return state;
+  return {
+    ...state,
+    dailyLimitMinutes: configuredLimitMinutes,
+  };
+}
+
+export function availableUsageSeconds(
+  settings: Settings,
+  state: DailyUsageState,
+  platform: PlatformId,
+): number {
+  const effectiveLimitMinutes =
+    state.dailyLimitMinutes >= 5
+      ? state.dailyLimitMinutes
+      : settings.dailyUsageLimitMinutes;
+  const dailyLimitSeconds = effectiveLimitMinutes * 60;
+  return Math.max(
+    0,
+    dailyLimitSeconds - state.usedSecondsByPlatform[platform],
+  );
 }
 
 export function availableAllowance(

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -2,9 +2,12 @@ import { storage } from "#imports";
 import {
   DEFAULT_SETTINGS,
   emptyDailyState,
+  emptyDailyUsageState,
   normalizeDailyState,
+  normalizeDailyUsageState,
   sanitizeSettings,
   type DailyState,
+  type DailyUsageState,
   type PlatformId,
   type Settings,
 } from "./models";
@@ -20,6 +23,13 @@ export const dailyStateItem = storage.defineItem<DailyState>(
   "local:dopamine-fast-daily-state",
   {
     defaultValue: emptyDailyState(),
+  },
+);
+
+export const dailyUsageStateItem = storage.defineItem<DailyUsageState>(
+  "local:dopamine-fast-daily-usage-state",
+  {
+    defaultValue: emptyDailyUsageState(),
   },
 );
 
@@ -62,6 +72,44 @@ export async function reserveAllowance(
   });
 
   return granted;
+}
+
+export async function getDailyUsageState(): Promise<DailyUsageState> {
+  const settings = await getSettings();
+  return normalizeDailyUsageState(
+    await dailyUsageStateItem.getValue(),
+    new Date(),
+    settings.dailyUsageLimitMinutes,
+  );
+}
+
+export async function addUsageSeconds(
+  platform: PlatformId,
+  elapsedSeconds: number,
+): Promise<number> {
+  const settings = await getSettings();
+  const stored = await dailyUsageStateItem.getValue();
+  const current = normalizeDailyUsageState(
+    stored,
+    new Date(),
+    settings.dailyUsageLimitMinutes,
+  );
+  const dailyLimitSeconds = current.dailyLimitMinutes * 60;
+  const increment = Math.max(0, Math.round(elapsedSeconds));
+  const usedSeconds = Math.min(
+    dailyLimitSeconds,
+    current.usedSecondsByPlatform[platform] + increment,
+  );
+
+  await dailyUsageStateItem.setValue({
+    ...current,
+    usedSecondsByPlatform: {
+      ...current.usedSecondsByPlatform,
+      [platform]: usedSeconds,
+    },
+  });
+
+  return Math.max(0, dailyLimitSeconds - usedSeconds);
 }
 
 export async function resetDailyState(): Promise<void> {

--- a/lib/usage-session.ts
+++ b/lib/usage-session.ts
@@ -1,0 +1,166 @@
+import type { InterventionUi } from "./intervention-ui";
+import type { PlatformId } from "./models";
+import { addUsageSeconds } from "./storage";
+
+export interface UsageSessionOptions {
+  platform: PlatformId;
+  platformLabel: string;
+  plannedSeconds: number;
+  availableSeconds: number;
+  ui: InterventionUi;
+  onPlannedTimeElapsed(availableSeconds: number): void;
+  onHardLimitReached(): void;
+}
+
+export class UsageSession {
+  private plannedSeconds: number;
+  private availableSeconds: number;
+  private pendingSeconds = 0;
+  private interval?: number;
+  private persistence = Promise.resolve();
+  private state: "idle" | "running" | "planned-end" | "hard-end" | "destroyed" =
+    "idle";
+  private readonly persistWhenHidden = () => {
+    if (document.visibilityState !== "visible") void this.persistPending();
+  };
+  private readonly persistBeforeLeaving = () => {
+    void this.persistPending();
+  };
+
+  constructor(private readonly options: UsageSessionOptions) {
+    this.availableSeconds = Math.max(0, options.availableSeconds);
+    this.plannedSeconds = Math.min(
+      Math.max(1, options.plannedSeconds),
+      this.availableSeconds,
+    );
+  }
+
+  start(): void {
+    if (this.state === "destroyed" || this.availableSeconds <= 0) {
+      this.finishHardLimit();
+      return;
+    }
+
+    this.state = "running";
+    this.render();
+    document.addEventListener("visibilitychange", this.persistWhenHidden);
+    window.addEventListener("pagehide", this.persistBeforeLeaving);
+    this.interval = window.setInterval(() => this.tick(), 1000);
+  }
+
+  extend(plannedSeconds: number): void {
+    if (this.state !== "planned-end" || this.availableSeconds <= 0) return;
+    this.plannedSeconds = Math.min(
+      Math.max(1, Math.round(plannedSeconds)),
+      this.availableSeconds,
+    );
+    this.state = "running";
+    this.render();
+    this.interval = window.setInterval(() => this.tick(), 1000);
+  }
+
+  async destroy(): Promise<void> {
+    if (this.state === "destroyed") return;
+    this.stopInterval();
+    this.state = "destroyed";
+    document.removeEventListener("visibilitychange", this.persistWhenHidden);
+    window.removeEventListener("pagehide", this.persistBeforeLeaving);
+    await this.persistPending();
+    this.options.ui.hideUsageTimer();
+  }
+
+  getAvailableSeconds(): number {
+    return this.availableSeconds;
+  }
+
+  private tick(): void {
+    if (this.state !== "running" || document.visibilityState !== "visible") {
+      return;
+    }
+
+    this.plannedSeconds = Math.max(0, this.plannedSeconds - 1);
+    this.availableSeconds = Math.max(0, this.availableSeconds - 1);
+    this.pendingSeconds += 1;
+    this.render();
+
+    if (this.availableSeconds <= 0) {
+      this.finishHardLimit();
+      return;
+    }
+
+    if (this.plannedSeconds <= 0) {
+      this.finishPlannedTime();
+      return;
+    }
+
+    if (this.pendingSeconds >= 5) {
+      void this.persistPending();
+    }
+  }
+
+  private render(): void {
+    this.options.ui.showUsageTimer({
+      platformLabel: this.options.platformLabel,
+      plannedSeconds: this.plannedSeconds,
+      availableSeconds: this.availableSeconds,
+    });
+  }
+
+  private finishPlannedTime(): void {
+    if (this.state !== "running") return;
+    this.stopInterval();
+    this.state = "planned-end";
+    void this.persistPending().then(() => {
+      if (this.state !== "planned-end") return;
+      if (this.availableSeconds <= 0) {
+        this.finishHardLimit();
+        return;
+      }
+      this.options.onPlannedTimeElapsed(this.availableSeconds);
+    });
+  }
+
+  private finishHardLimit(): void {
+    if (this.state === "hard-end" || this.state === "destroyed") return;
+    this.stopInterval();
+    this.state = "hard-end";
+    this.plannedSeconds = 0;
+    this.availableSeconds = 0;
+    this.render();
+    void this.persistPending().then(() => {
+      if (this.state === "hard-end") this.options.onHardLimitReached();
+    });
+  }
+
+  private persistPending(): Promise<void> {
+    const seconds = this.pendingSeconds;
+    this.pendingSeconds = 0;
+    if (seconds <= 0) return this.persistence;
+
+    this.persistence = this.persistence.then(async () => {
+      const storedRemaining = await addUsageSeconds(
+        this.options.platform,
+        seconds,
+      );
+      this.availableSeconds = Math.min(
+        this.availableSeconds,
+        storedRemaining,
+      );
+
+      if (this.state !== "destroyed") {
+        this.render();
+        if (this.availableSeconds <= 0 && this.state !== "hard-end") {
+          this.finishHardLimit();
+        }
+      }
+    });
+    return this.persistence;
+  }
+
+  private stopInterval(): void {
+    if (this.interval !== undefined) {
+      window.clearInterval(this.interval);
+      this.interval = undefined;
+    }
+  }
+}

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_SETTINGS,
   availableAllowance,
+  availableUsageSeconds,
   emptyDailyState,
+  emptyDailyUsageState,
   localDateKey,
   normalizeDailyState,
+  normalizeDailyUsageState,
   sanitizeSettings,
 } from "../lib/models";
 
@@ -12,6 +15,8 @@ describe("settings", () => {
   it("uses safe defaults and clamps numeric values", () => {
     const settings = sanitizeSettings({
       openingDelaySeconds: 900,
+      sessionDurationMinutes: 0,
+      dailyUsageLimitMinutes: 900,
       batchSize: 0,
       unlockBatchSize: 300,
       dailyLimit: -10,
@@ -19,6 +24,8 @@ describe("settings", () => {
     });
 
     expect(settings.openingDelaySeconds).toBe(60);
+    expect(settings.sessionDurationMinutes).toBe(1);
+    expect(settings.dailyUsageLimitMinutes).toBe(240);
     expect(settings.batchSize).toBe(5);
     expect(settings.unlockBatchSize).toBe(50);
     expect(settings.dailyLimit).toBe(10);
@@ -51,5 +58,49 @@ describe("daily state", () => {
     expect(
       availableAllowance({ ...DEFAULT_SETTINGS, dailyLimit: 60 }, state),
     ).toBe(25);
+  });
+
+  it("resets stale time usage and calculates a per-network hard limit", () => {
+    const staleUsage = {
+      ...emptyDailyUsageState(new Date(2026, 6, 28), 10),
+      usedSecondsByPlatform: {
+        reddit: 900,
+        x: 0,
+        instagram: 0,
+      },
+    };
+    const currentUsage = normalizeDailyUsageState(staleUsage, today, 10);
+
+    expect(currentUsage).toEqual(emptyDailyUsageState(today, 10));
+
+    currentUsage.usedSecondsByPlatform.reddit = 420;
+    expect(
+      availableUsageSeconds(
+        { ...DEFAULT_SETTINGS, dailyUsageLimitMinutes: 10 },
+        currentUsage,
+        "reddit",
+      ),
+    ).toBe(180);
+    expect(
+      availableUsageSeconds(
+        { ...DEFAULT_SETTINGS, dailyUsageLimitMinutes: 10 },
+        currentUsage,
+        "x",
+      ),
+    ).toBe(600);
+  });
+
+  it("keeps the effective time limit fixed until the next day", () => {
+    const usage = emptyDailyUsageState(today, 20);
+    const normalized = normalizeDailyUsageState(usage, today, 60);
+
+    expect(normalized.dailyLimitMinutes).toBe(20);
+    expect(
+      availableUsageSeconds(
+        { ...DEFAULT_SETTINGS, dailyUsageLimitMinutes: 60 },
+        normalized,
+        "reddit",
+      ),
+    ).toBe(1200);
   });
 });


### PR DESCRIPTION
## What changed

- Adds an intentional session duration before entering Reddit, X or Instagram.
- Keeps a compact floating countdown visible during use.
- Enforces an independent daily time ceiling for each supported network.
- Stops planned sessions and allows a deliberate additional block while daily time remains.
- Counts time only while the feed tab is visible and persists aggregate seconds locally.
- Preserves the finite-batch boundary when it coincides with the session timer.

## Privacy

Only aggregate elapsed seconds per network and local day are stored. The change adds no permissions, reads no post content and sends no data outside the browser.

## Validation

- `npm run validate`
- 9 tests passing
- Firefox MV2 and Chromium MV3 production builds
- `npm audit --audit-level=high`

## Manual testing still needed

The full interaction should be tested on real pages in Firefox for Android, especially SPA navigation, tab suspension and timer persistence.