### PR TITLE
fix: use English for application interface

### DIFF
--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -8,6 +8,7 @@ Keep the useful parts of social networks while giving every feed a real end.
 
 - Firefox for Android
 - Reddit, X and Instagram mobile websites
+- English-language application interface
 - Authenticated browser sessions, including private content the user is already
   authorized to see
 

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -1,19 +1,19 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Dopamine Fast — Ajustes</title>
+    <title>Dopamine Fast — Settings</title>
     <script type="module" src="./main.ts"></script>
   </head>
   <body>
     <main class="settings-shell">
       <header class="hero">
-        <p class="eyebrow">Dopamine Fast / Ajustes locales</p>
-        <h1>Haz que el feed<br />tenga un final.</h1>
+        <p class="eyebrow">Dopamine Fast / Local settings</p>
+        <h1>Give your feed<br />a real ending.</h1>
         <p class="hero-copy">
-          Estos límites viven solo en tu navegador. No analizamos ni enviamos
-          el contenido que ves.
+          These limits live only in your browser. We do not analyze or send
+          the content you see.
         </p>
       </header>
 
@@ -21,8 +21,8 @@
         <section class="panel panel--status">
           <label class="master-toggle">
             <span>
-              <strong>Protección activa</strong>
-              <small>Pausa y limita los feeds compatibles.</small>
+              <strong>Protection enabled</strong>
+              <small>Pause and limit supported feeds.</small>
             </span>
             <input id="enabled" name="enabled" type="checkbox" />
             <span class="switch" aria-hidden="true"></span>
@@ -32,16 +32,16 @@
         <section class="panel">
           <div class="section-number">01</div>
           <div class="section-heading">
-            <h2>Tiempo consciente</h2>
+            <h2>Intentional time</h2>
             <p>
-              Elige una intención por sesión y un techo diario que no se puede
-              desbloquear.
+              Choose an intention for each session and a daily ceiling that
+              cannot be unlocked.
             </p>
           </div>
 
           <div class="number-grid number-grid--two">
             <label class="number-field">
-              <span>Sesión sugerida</span>
+              <span>Suggested session</span>
               <input
                 id="session-duration"
                 name="sessionDurationMinutes"
@@ -50,11 +50,11 @@
                 max="60"
                 step="1"
               />
-              <small>minutos, ajustables al entrar</small>
+              <small>minutes, adjustable when entering</small>
             </label>
 
             <label class="number-field">
-              <span>Máximo diario por red</span>
+              <span>Daily maximum per network</span>
               <input
                 id="daily-usage-limit"
                 name="dailyUsageLimitMinutes"
@@ -63,7 +63,7 @@
                 max="240"
                 step="5"
               />
-              <small>minutos, fijo hasta mañana</small>
+              <small>minutes, fixed until tomorrow</small>
             </label>
           </div>
         </section>
@@ -71,12 +71,12 @@
         <section class="panel">
           <div class="section-number">02</div>
           <div class="section-heading">
-            <h2>Ritmo de entrada</h2>
-            <p>Introduce una pausa antes de abrir un feed.</p>
+            <h2>Entry pace</h2>
+            <p>Add a pause before opening a feed.</p>
           </div>
 
           <label class="field">
-            <span>Pausa al entrar</span>
+            <span>Pause before entering</span>
             <output id="opening-delay-output" for="opening-delay"></output>
             <input
               id="opening-delay"
@@ -89,7 +89,7 @@
           </label>
 
           <label class="field">
-            <span>Espera antes de desbloquear</span>
+            <span>Wait before unlocking</span>
             <output id="unlock-delay-output" for="unlock-delay"></output>
             <input
               id="unlock-delay"
@@ -105,13 +105,13 @@
         <section class="panel">
           <div class="section-number">03</div>
           <div class="section-heading">
-            <h2>Tamaño del feed</h2>
-            <p>Cada lote termina de verdad. Tú decides si abres otro.</p>
+            <h2>Feed size</h2>
+            <p>Every batch truly ends. You decide whether to open another.</p>
           </div>
 
           <div class="number-grid">
             <label class="number-field">
-              <span>Primer lote</span>
+              <span>First batch</span>
               <input
                 id="batch-size"
                 name="batchSize"
@@ -120,11 +120,11 @@
                 max="100"
                 step="5"
               />
-              <small>publicaciones</small>
+              <small>posts</small>
             </label>
 
             <label class="number-field">
-              <span>Lotes extra</span>
+              <span>Extra batches</span>
               <input
                 id="unlock-batch-size"
                 name="unlockBatchSize"
@@ -133,11 +133,11 @@
                 max="50"
                 step="5"
               />
-              <small>publicaciones</small>
+              <small>posts</small>
             </label>
 
             <label class="number-field">
-              <span>Máximo diario</span>
+              <span>Daily maximum</span>
               <input
                 id="daily-limit"
                 name="dailyLimit"
@@ -146,7 +146,7 @@
                 max="500"
                 step="10"
               />
-              <small>entre todas las redes</small>
+              <small>across all networks</small>
             </label>
           </div>
         </section>
@@ -154,36 +154,36 @@
         <section class="panel">
           <div class="section-number">04</div>
           <div class="section-heading">
-            <h2>Fricción</h2>
-            <p>Cuánto cuesta elegir conscientemente otro lote.</p>
+            <h2>Friction</h2>
+            <p>How much effort it takes to intentionally choose another batch.</p>
           </div>
 
           <div class="mode-grid">
             <label class="mode-card">
               <input type="radio" name="mode" value="gentle" />
               <span>
-                <strong>Suave</strong>
-                <small>Lotes extra sin máximo de desbloqueos.</small>
+                <strong>Gentle</strong>
+                <small>Extra batches without an unlock limit.</small>
               </span>
             </label>
             <label class="mode-card">
               <input type="radio" name="mode" value="balanced" />
               <span>
-                <strong>Equilibrado</strong>
-                <small>Hasta dos desbloqueos por día.</small>
+                <strong>Balanced</strong>
+                <small>Up to two unlocks per day.</small>
               </span>
             </label>
             <label class="mode-card">
               <input type="radio" name="mode" value="strict" />
               <span>
-                <strong>Estricto</strong>
-                <small>El máximo diario manda.</small>
+                <strong>Strict</strong>
+                <small>The daily maximum always applies.</small>
               </span>
             </label>
           </div>
 
           <label class="field">
-            <span>Mantener pulsado</span>
+            <span>Press-and-hold time</span>
             <output id="hold-output" for="hold-seconds"></output>
             <input
               id="hold-seconds"
@@ -199,16 +199,16 @@
         <section class="panel">
           <div class="section-number">05</div>
           <div class="section-heading">
-            <h2>Redes y ruido</h2>
-            <p>La detección es inicial: afinaremos selectores al probarla.</p>
+            <h2>Networks and noise</h2>
+            <p>Detection is an early version; selectors will evolve with testing.</p>
           </div>
 
           <div class="toggle-list">
             <label><span>Reddit</span><input id="site-reddit" type="checkbox" /></label>
             <label><span>X / Twitter</span><input id="site-x" type="checkbox" /></label>
             <label><span>Instagram</span><input id="site-instagram" type="checkbox" /></label>
-            <label><span>Ocultar sugerencias</span><input id="block-suggested" type="checkbox" /></label>
-            <label><span>Detener reproducción automática</span><input id="disable-autoplay" type="checkbox" /></label>
+            <label><span>Hide suggestions</span><input id="block-suggested" type="checkbox" /></label>
+            <label><span>Stop autoplay</span><input id="disable-autoplay" type="checkbox" /></label>
           </div>
         </section>
 
@@ -216,10 +216,10 @@
           <p id="save-status" role="status" aria-live="polite"></p>
           <div>
             <button class="button button--quiet" id="reset-day" type="button">
-              Reiniciar publicaciones de hoy
+              Reset today's post count
             </button>
             <button class="button button--primary" type="submit">
-              Guardar cambios
+              Save changes
             </button>
           </div>
         </footer>

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -105,7 +105,7 @@ form.addEventListener("submit", async (event) => {
   event.preventDefault();
   await saveSettings(readSettings());
   status.textContent =
-    "Guardado. Si hoy ya usaste una red, su nuevo techo se aplica mañana.";
+    "Saved. If you already used a network today, its new ceiling applies tomorrow.";
   window.setTimeout(() => {
     status.textContent = "";
   }, 2400);
@@ -115,7 +115,7 @@ requiredElement<HTMLButtonElement>("#reset-day").addEventListener(
   "click",
   async () => {
     await resetDailyState();
-    status.textContent = "El contador de publicaciones vuelve a cero.";
+    status.textContent = "Today's post count has been reset.";
   },
 );
 

--- a/lib/intervention-ui.ts
+++ b/lib/intervention-ui.ts
@@ -28,10 +28,10 @@ export interface SessionEndedOptions {
 }
 
 const intentions = [
-  ["specific", "Busco algo concreto"],
-  ["reply", "Quiero responder o interactuar"],
-  ["deliberate", "Quiero seguir leyendo"],
-  ["automatic", "Estoy bajando por inercia"],
+  ["specific", "I'm looking for something specific"],
+  ["reply", "I want to reply or interact"],
+  ["deliberate", "I want to keep reading"],
+  ["automatic", "I'm scrolling on autopilot"],
 ] as const;
 
 export class InterventionUi {
@@ -80,18 +80,18 @@ export class InterventionUi {
     this.overlay.innerHTML = `
       <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-opening-title">
         <article class="df-card df-card--opening">
-          <p class="df-kicker">Una pausa antes de entrar</p>
+          <p class="df-kicker">A pause before entering</p>
           ${
             options.delaySeconds > 0
               ? `<div class="df-countdown" aria-live="polite">${options.delaySeconds}</div>`
               : `<div class="df-pause-mark df-pause-mark--centered" aria-hidden="true"></div>`
           }
-          <h1 id="df-opening-title">¿Cuánto tiempo quieres dedicar a ${options.platformLabel}?</h1>
+          <h1 id="df-opening-title">How much time do you want to spend on ${options.platformLabel}?</h1>
           <p class="df-copy">
-            Elige ahora una sesión concreta. El contador seguirá visible mientras navegas.
+            Choose a defined session now. The timer will remain visible as you browse.
           </p>
           <label class="df-time-choice">
-            <span>Esta sesión</span>
+            <span>This session</span>
             <output for="df-session-minutes">${defaultSessionLabel}</output>
             <input
               id="df-session-minutes"
@@ -104,20 +104,20 @@ export class InterventionUi {
             />
           </label>
           <p class="df-hard-limit-note">
-            Quedan <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong>
-            del límite diario de esta red.
+            You have <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong>
+            left in today's limit for this network.
           </p>
           <div class="df-actions">
-            <button class="df-button df-button--quiet" data-action="leave">Salir</button>
+            <button class="df-button df-button--quiet" data-action="leave">Leave</button>
             <button class="df-button df-button--primary" data-action="continue" disabled>
               ${
                 options.delaySeconds > 0
-                  ? `Continuar en ${options.delaySeconds}s`
-                  : `Entrar ${defaultSessionLabel}`
+                  ? `Continue in ${options.delaySeconds}s`
+                  : `Start ${defaultSessionLabel} session`
               }
             </button>
           </div>
-          <button class="df-settings-link" data-action="settings">Ajustar tiempos y límites</button>
+          <button class="df-settings-link" data-action="settings">Adjust time and limits</button>
         </article>
       </section>
     `;
@@ -144,7 +144,7 @@ export class InterventionUi {
         options.availableSeconds < 60 ? "<1 min" : `${sessionInput.value} min`;
       sessionOutput.value = label;
       if (!continueButton.disabled) {
-        continueButton.textContent = `Entrar ${label}`;
+        continueButton.textContent = `Start ${label} session`;
       }
     });
 
@@ -163,12 +163,12 @@ export class InterventionUi {
           if (countdown) countdown.textContent = String(Math.max(0, remaining));
           continueButton.textContent =
             remaining > 0
-              ? `Continuar en ${remaining}s`
-              : `Entrar ${
+              ? `Continue in ${remaining}s`
+              : `Start ${
                   options.availableSeconds < 60
                     ? "<1 min"
                     : `${sessionInput.value} min`
-                }`;
+                } session`;
 
           if (remaining <= 0) {
             if (interval !== undefined) window.clearInterval(interval);
@@ -196,22 +196,22 @@ export class InterventionUi {
       <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-end-title">
         <article class="df-card">
           <div class="df-rule"></div>
-          <p class="df-kicker">Fin del lote</p>
-          <h1 id="df-end-title">Ya has terminado por ahora.</h1>
+          <p class="df-kicker">End of batch</p>
+          <h1 id="df-end-title">That's enough for now.</h1>
           <p class="df-copy">
             ${options.remainingToday > 0
-              ? `Quedan ${options.remainingToday} publicaciones en tu límite de hoy.`
-              : "Has alcanzado tu límite diario."}
+              ? `You have ${options.remainingToday} posts left in today's limit.`
+              : "You've reached today's limit."}
           </p>
           <div class="df-actions df-actions--stack">
-            <button class="df-button df-button--primary" data-action="leave">Salir de ${options.platformLabel}</button>
+            <button class="df-button df-button--primary" data-action="leave">Leave ${options.platformLabel}</button>
             ${
               options.canUnlock
-                ? `<button class="df-button df-button--quiet" data-action="unlock">Desbloquear ${options.unlockSize} más</button>`
+                ? `<button class="df-button df-button--quiet" data-action="unlock">Unlock ${options.unlockSize} more</button>`
                 : ""
             }
           </div>
-          <button class="df-settings-link" data-action="settings">Cambiar límites</button>
+          <button class="df-settings-link" data-action="settings">Change limits</button>
         </article>
       </section>
     `;
@@ -241,13 +241,13 @@ export class InterventionUi {
       <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-session-end-title">
         <article class="df-card">
           <div class="df-rule"></div>
-          <p class="df-kicker">Tiempo elegido completado</p>
-          <h1 id="df-session-end-title">Tu sesión ya terminó.</h1>
+          <p class="df-kicker">Planned time complete</p>
+          <h1 id="df-session-end-title">Your session has ended.</h1>
           <p class="df-copy">
-            Elegiste parar aquí. Si todavía tienes un motivo concreto, puedes planear otro bloque.
+            You chose to stop here. If you still have a specific reason, you can plan another block.
           </p>
           <label class="df-time-choice">
-            <span>Nuevo bloque</span>
+            <span>New block</span>
             <output for="df-extra-minutes">${defaultSessionLabel}</output>
             <input
               id="df-extra-minutes"
@@ -260,14 +260,14 @@ export class InterventionUi {
             />
           </label>
           <p class="df-hard-limit-note">
-            El techo diario no se puede ampliar:
-            <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong> disponibles.
+            Your daily ceiling cannot be extended:
+            <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong> remaining.
           </p>
           <div class="df-actions">
-            <button class="df-button df-button--primary" data-action="leave">Salir de ${options.platformLabel}</button>
-            <button class="df-button df-button--quiet" data-action="extend">Planear otro bloque</button>
+            <button class="df-button df-button--primary" data-action="leave">Leave ${options.platformLabel}</button>
+            <button class="df-button df-button--quiet" data-action="extend">Plan another block</button>
           </div>
-          <button class="df-settings-link" data-action="settings">Cambiar el valor predeterminado</button>
+          <button class="df-settings-link" data-action="settings">Change the default</button>
         </article>
       </section>
     `;
@@ -308,15 +308,15 @@ export class InterventionUi {
       <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-hard-limit-title">
         <article class="df-card">
           <div class="df-lock-mark" aria-hidden="true"></div>
-          <p class="df-kicker">Límite diario completado</p>
-          <h1 id="df-hard-limit-title">${platformLabel} termina aquí por hoy.</h1>
+          <p class="df-kicker">Daily limit reached</p>
+          <h1 id="df-hard-limit-title">${platformLabel} ends here for today.</h1>
           <p class="df-copy">
-            Este límite no tiene desbloqueo. Volverá a estar disponible mañana.
+            This limit cannot be unlocked. It will be available again tomorrow.
           </p>
           <div class="df-actions df-actions--stack">
-            <button class="df-button df-button--primary" data-action="leave">Salir de ${platformLabel}</button>
+            <button class="df-button df-button--primary" data-action="leave">Leave ${platformLabel}</button>
           </div>
-          <button class="df-settings-link" data-action="settings">Ver configuración</button>
+          <button class="df-settings-link" data-action="settings">View settings</button>
         </article>
       </section>
     `;
@@ -330,11 +330,11 @@ export class InterventionUi {
   showUsageTimer(options: UsageTimerOptions): void {
     if (this.timer.childElementCount === 0) {
       this.timer.innerHTML = `
-        <button class="df-usage-timer" type="button" title="Abrir los ajustes de Dopamine Fast">
+        <button class="df-usage-timer" type="button" title="Open Dopamine Fast settings">
           <span class="df-usage-timer__pulse" aria-hidden="true"></span>
           <span class="df-usage-timer__copy">
             <strong data-timer="planned"></strong>
-            <small><span data-timer="platform"></span> · <span data-timer="daily"></span> hoy</small>
+            <small><span data-timer="platform"></span> · <span data-timer="daily"></span> today</small>
           </span>
         </button>
       `;
@@ -360,7 +360,7 @@ export class InterventionUi {
         : "false";
     timer.setAttribute(
       "aria-label",
-      `${this.formatClock(options.plannedSeconds)} de sesión; ${this.formatFriendlyDuration(options.availableSeconds)} disponibles hoy en ${options.platformLabel}`,
+      `${this.formatClock(options.plannedSeconds)} left in this session; ${this.formatFriendlyDuration(options.availableSeconds)} available today on ${options.platformLabel}`,
     );
   }
 
@@ -371,8 +371,8 @@ export class InterventionUi {
   private showIntentionStep(options: EndOfBatchOptions): void {
     const card = this.requiredElement<HTMLElement>(".df-card");
     card.innerHTML = `
-      <p class="df-step">Paso 1 de 2</p>
-      <h1>¿Para qué quieres continuar?</h1>
+      <p class="df-step">Step 1 of 2</p>
+      <h1>Why do you want to continue?</h1>
       <div class="df-intentions">
         ${intentions
           .map(
@@ -384,7 +384,7 @@ export class InterventionUi {
           )
           .join("")}
       </div>
-      <button class="df-settings-link" data-action="back">Volver</button>
+      <button class="df-settings-link" data-action="back">Back</button>
     `;
 
     card
@@ -399,16 +399,16 @@ export class InterventionUi {
   private showHoldStep(options: EndOfBatchOptions): void {
     const card = this.requiredElement<HTMLElement>(".df-card");
     card.innerHTML = `
-      <p class="df-step">Paso 2 de 2</p>
+      <p class="df-step">Step 2 of 2</p>
       <div class="df-pause-mark" aria-hidden="true"></div>
-      <h1>Espera un momento.</h1>
-      <p class="df-copy">Después mantén pulsado para abrir otro lote.</p>
+      <h1>Pause for a moment.</h1>
+      <p class="df-copy">Then press and hold to open another batch.</p>
       <button class="df-hold" data-action="hold" disabled style="--df-hold-progress: 0%">
-        <span>Mantén pulsado</span>
+        <span>Press and hold</span>
         <span class="df-hold__progress" aria-hidden="true"></span>
       </button>
       <p class="df-wait" aria-live="polite"></p>
-      <button class="df-settings-link" data-action="back">Volver</button>
+      <button class="df-settings-link" data-action="back">Back</button>
     `;
 
     const holdButton =
@@ -418,7 +418,7 @@ export class InterventionUi {
 
     const updateWait = () => {
       waitLabel.textContent =
-        remaining > 0 ? `Disponible en ${remaining}s` : "Cuando quieras.";
+        remaining > 0 ? `Available in ${remaining}s` : "Whenever you're ready.";
     };
     updateWait();
 
@@ -453,7 +453,7 @@ export class InterventionUi {
       if (progress >= 1) {
         completed = true;
         holdButton.disabled = true;
-        holdButton.querySelector("span")!.textContent = "Preparando…";
+        holdButton.querySelector("span")!.textContent = "Preparing…";
         const granted = await options.onUnlock();
         if (granted > 0) {
           this.hide();


### PR DESCRIPTION
## Delivery order

This PR targets `main` directly and depends on #22. Merge #22 first; until then this PR's diff includes the timer commit as well as the application-language change. After #22 lands, GitHub will reduce this PR to its own commit automatically.

## What changed

- Translated the opening pause, session timer, batch boundary, unlock flow and hard-limit screens to English.
- Translated the complete options page and its dynamic status messages.
- Changed the options document language to `en`.
- Recorded English as the application language in the product specification.
- Kept localized Spanish platform tokens used internally to detect suggested or promoted content; they are not displayed in the UI.

## Why

English is the canonical product language and all user-facing copy should be consistent, including accessibility labels and dynamic states.

## Validation

- `npm run validate`
- 9 tests passing
- Firefox MV2 production build
- Chromium MV3 production build
- Repository scan found no remaining Spanish user-interface copy