### PR TITLE
docs: add repository agent guidance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,8 +36,10 @@ updates:
     versioning-strategy: "increase-if-necessary"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
+    # Conventional Commits: deps(deps): ... or deps(deps-dev): ...
     commit-message:
       prefix: "deps"
+      prefix-development: "deps"
       include: "scope"
     labels:
       - "dependencies"
@@ -59,6 +61,7 @@ updates:
         applies-to: "version-updates"
         patterns:
           - "*"
+    # Conventional Commits: deps(deps): ...
     commit-message:
       prefix: "deps"
       include: "scope"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,8 @@
 ## Contribution checklist
 
 - [ ] The PR has one clear purpose and its title follows Conventional Commits.
+- [ ] The PR targets `main`; dependencies on other open PRs and their merge
+      order are documented above.
 - [ ] I added or updated tests for behavior that can be tested automatically.
 - [ ] I documented user-facing settings or behavior changes.
 - [ ] I did not add analytics, remote data collection or new permissions without

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,408 @@
+# AGENTS.md
+
+This file is the working guide for coding agents and contributors in this
+repository. It describes the product and architecture as they exist today,
+plus the invariants that changes must preserve.
+
+This is the canonical shared instruction file for coding agents. `CLAUDE.md`
+imports it for Claude Code compatibility. Keep common guidance here instead of
+duplicating it in tool-specific files.
+
+## Quick start
+
+Use Node.js 22 or newer. CI currently runs Node.js 24.
+
+```sh
+npm ci
+npm run dev             # Firefox development build
+npm run dev:chrome      # Chromium development build
+npm run validate        # types, unit tests and both production builds
+npm run zip             # distributable Firefox and Chromium ZIPs
+```
+
+Run `npm run validate` before handing off a code change. Run `npm run zip` as
+well when changing the manifest, entrypoints, assets, build configuration or
+release packaging.
+
+Generated directories (`.output/`, `.wxt/`, `dist/`, `coverage/` and
+`node_modules/`) must not be committed or edited by hand.
+
+## Product intent
+
+Dopamine Fast is a local-first browser extension that makes supported social
+feeds finite and intentional without copying or aggregating their content.
+The initial product target is Firefox for Android, with Chromium builds kept
+working.
+
+Supported networks:
+
+- Reddit
+- X/Twitter
+- Instagram
+
+The extension operates on the authenticated web pages the user already visits.
+It does not use platform APIs, scrape in the background, read private messages,
+send browsing data to a service, or provide a unified feed.
+
+The product principles are:
+
+1. Preserve useful, user-requested access to social networks.
+2. Add friction before and during habitual feed consumption.
+3. Give feeds a visible end through finite post batches.
+4. Keep hard daily limits outside the in-page unlock flow.
+5. Store only preferences and aggregate counters, locally.
+6. Request the minimum browser and host permissions required.
+7. Fail safely when a platform changes its DOM.
+
+`PRODUCT_SPEC.md` defines the intended behavior. `README.md` describes the
+user-facing implementation. When either document disagrees with executable
+behavior, call out the discrepancy rather than silently choosing one.
+
+## Current feature model
+
+On a supported feed route, the content script:
+
+1. Loads sanitized settings and the current local-day usage state.
+2. Stops immediately when the extension/site is disabled or the route is not a
+   feed.
+3. Blocks entry when the per-network daily time ceiling is exhausted.
+4. Shows a configurable opening delay and asks for an intended session length.
+5. Reserves the initial post allowance and starts the finite-feed limiter.
+6. Counts time only while the document is visible and shows a floating timer.
+7. Stops at the selected session duration and asks the user to leave or choose
+   another block.
+8. Enforces the daily time ceiling without an in-page extension or reset.
+9. Shows an end-of-batch intervention before revealing more posts.
+
+Post and time budgets intentionally have different scopes:
+
+- `DailyState.revealed` and `DailyState.unlocks` are global across all supported
+  networks for the local calendar day.
+- `DailyState.revealedByPlatform` is aggregate reporting data; it does not
+  currently enforce a separate post limit.
+- `DailyUsageState.usedSecondsByPlatform` enforces an independent time ceiling
+  for each network.
+- The effective time ceiling is captured when the day's state is created.
+  Changing the setting applies on the next local calendar day.
+
+Mode behavior currently differs mainly in unlock policy: balanced mode permits
+two extra batches per day, while gentle and strict are still primarily bounded
+by the global daily post maximum. The stricter fail-closed behavior described
+in `PRODUCT_SPEC.md` is not fully implemented; do not claim otherwise.
+
+## Technology and extension constraints
+
+- WXT `0.21.x` supplies the extension build system and WebExtension globals.
+- TypeScript is strict, with `noUncheckedIndexedAccess` and
+  `noImplicitOverride`.
+- The options page and injected intervention UI use native DOM APIs and CSS;
+  there is no application UI framework.
+- All user-facing application copy is written in English. Keep non-English
+  platform tokens only when they are needed to detect localized suggested or
+  promoted content.
+- Vitest provides unit tests.
+- Firefox builds target Manifest V2; Chromium builds target Manifest V3.
+- The manifest requests only local `storage` plus the host access implied by
+  content-script matches.
+- The injected interface is isolated in a WXT shadow root.
+
+Keep the dependency set small. Prefer browser APIs and focused modules over
+adding a framework for isolated UI behavior. Pin npm dependencies exactly and
+pin third-party GitHub Actions to full commit SHAs.
+
+## Repository map
+
+```text
+entrypoints/
+  content.ts             Runtime composition root for supported pages
+  options/
+    index.html           Settings markup
+    main.ts              Settings form binding and persistence
+    style.css            Options-page presentation
+lib/
+  models.ts              Domain types, defaults, sanitization and pure rules
+  storage.ts             WXT storage keys and persistence operations
+  platforms.ts           Host/route detection and selector adapters
+  feed-limiter.ts        DOM observation, post visibility and batch boundaries
+  usage-session.ts       Visible-tab session timer and persistence lifecycle
+  intervention-ui.ts     Shadow-DOM overlays, timer and deliberate interactions
+assets/content.css       Injected shadow-root presentation
+tests/                   Vitest unit tests for pure domain/platform behavior
+public/                  Extension icons copied by WXT
+wxt.config.ts            Manifest metadata and packaging configuration
+PRODUCT_SPEC.md          Product behavior and scope
+SOURCE_CODE_REVIEW.md    Reproducible Firefox build instructions
+.github/                 CI, Release Please, Dependabot and contribution policy
+```
+
+## Architectural boundaries
+
+Maintain this dependency direction:
+
+```text
+entrypoints -> orchestration and browser lifecycle
+            -> lib services and domain modules
+
+feed-limiter / usage-session / intervention-ui
+            -> models, storage or platform contracts as needed
+
+storage / platforms -> models
+models             -> no browser or DOM dependencies
+```
+
+Specific responsibilities:
+
+- `entrypoints/content.ts` composes services, reacts to SPA navigation/settings
+  changes and owns activation cancellation. Keep policy and DOM algorithms out
+  of it.
+- `models.ts` must remain deterministic and easy to unit test. Put defaults,
+  clamps, date normalization and pure budget calculations here.
+- `storage.ts` owns storage key names and all persistent reads/writes. Other
+  modules must not introduce ad-hoc storage keys.
+- `platforms.ts` is the only home for network-specific hosts, feed routes,
+  selectors and recommendation markers.
+- `feed-limiter.ts` may manipulate feed elements, but it must restore every
+  style it changes when destroyed.
+- `usage-session.ts` owns timer state and persistence cadence, not overlay
+  markup.
+- `intervention-ui.ts` owns rendering and direct UI interaction, not storage or
+  platform detection.
+
+`intervention-ui.ts` is already the largest module. When adding another
+substantial screen or interaction state, split it by intervention or introduce
+a small view/state abstraction instead of continuing to grow one class.
+
+## State and concurrency invariants
+
+All persisted values must pass through normalization or sanitization when read
+and before they influence behavior. New fields require safe defaults so
+existing installations continue to work without a migration.
+
+Preserve these invariants:
+
+- Calendar resets use the user's local date, not UTC.
+- Numeric settings are finite integers constrained to product-safe ranges.
+- Usage is counted only while the supported feed document is visible.
+- Pending seconds are persisted on visibility loss, page hide and teardown.
+- A time-limit change cannot increase the effective ceiling for the current
+  day.
+- Repeated activation must cancel stale asynchronous UI results.
+- Teardown must clear timers, observers and listeners and restore page state.
+
+Important known limitation: `storage.ts` currently performs read-modify-write
+updates from content scripts. Two active tabs can race and lose post
+reservations or elapsed-time increments. Before describing daily ceilings as
+reliable across concurrent tabs, route mutations through one background owner
+(or another serialized transaction mechanism) and add multi-tab tests. This is
+the highest-priority architectural hardening.
+
+## Platform adapter changes
+
+Social DOM selectors are volatile. A selector must be narrowly scoped and must
+not hide a broad parent container when confidence is low. Recommendation text
+matching is a fallback, not a reason to inspect or retain post bodies.
+
+When adding or changing a platform:
+
+1. Update `PlatformId`, default settings and per-platform state shapes.
+2. Add/update the adapter, host recognition, feed-route rules and selectors.
+3. Update the content-script match patterns.
+4. Expose the site in the options UI.
+5. Add unit tests for host and route boundaries.
+6. Manually test signed-in mobile and desktop layouts where available.
+7. Document the tested browser, viewport and network in the PR.
+
+Direct profiles, messages, settings and post-detail routes should remain
+usable and outside the limiter unless the product specification explicitly
+changes.
+
+## DOM, privacy and security rules
+
+Treat the host page as untrusted input:
+
+- Never inject social-network text with `innerHTML`.
+- Do not execute remote code or load scripts/styles from a CDN.
+- Do not read cookies, authentication tokens, private messages or unnecessary
+  post content.
+- Do not add analytics, telemetry, remote logging or a backend without an
+  explicit product decision and privacy review.
+- Do not broaden permissions or match patterns incidentally.
+- Keep overlays accessible: dialog semantics, labels, live regions, keyboard
+  behavior and usable touch targets matter.
+- Page locks must restore the original `html` and `body` overflow values.
+- Observers and DOM scans must be debounced and bounded; social feeds mutate
+  continuously.
+
+A “hard” limit means no bypass exposed by the extension UI. Users still control
+their browser, storage and installed extensions; documentation must not imply
+tamper-proof enforcement.
+
+## Code Review Rules
+
+Review for behavioral and security regressions, not formatting that CI can
+enforce. Flag a change when it:
+
+- broadens browser permissions, host matches or collected data without a
+  documented need and privacy analysis;
+- sends local state or page-derived data off-device;
+- inserts host-page content through `innerHTML` or introduces remote code;
+- weakens a hard limit, exposes a time-counter reset or lets current-day
+  settings increases take effect immediately;
+- mutates daily state outside `storage.ts` or adds another non-serialized
+  read-modify-write path;
+- fails to cancel stale activations, timers, observers or listeners;
+- hides content with selectors broad enough to remove user-requested posts or
+  unrelated page controls;
+- changes a supported route without a boundary test;
+- adds a setting without sanitization and a backward-compatible default;
+- changes visible behavior without corresponding product documentation.
+
+When flagging selector fragility, propose a narrower selector or a fail-open
+guard. When flagging state correctness, prefer a serialized background owner
+over timing-based retries in individual tabs.
+
+## Settings changes
+
+For every new setting:
+
+1. Add it to `Settings` and `DEFAULT_SETTINGS`.
+2. Sanitize/clamp it in `sanitizeSettings`.
+3. Add backward-compatible rendering and form reading in the options page.
+4. Decide whether a mid-session update applies immediately, on reactivation or
+   on the next local day.
+5. Add model tests for invalid, missing and boundary values.
+6. Update `PRODUCT_SPEC.md` and `README.md` when behavior is user-visible.
+
+Do not provide an options-page reset for elapsed time. The existing reset
+button resets the post counter only.
+
+## Testing strategy
+
+Automated tests should focus on deterministic behavior:
+
+- settings sanitization and backward compatibility;
+- date rollover and budget calculations;
+- host and feed-route boundaries;
+- session state transitions and persistence, using fakes where necessary;
+- selector fixtures and safe failure behavior;
+- concurrent storage updates once a serialized state owner exists.
+
+Minimum validation by change type:
+
+| Change | Required validation |
+| --- | --- |
+| Documentation only | Inspect links and diff |
+| Pure model/platform rule | `npm test` and `npm run typecheck` |
+| Runtime, options or CSS | `npm run validate` |
+| Manifest/build/release | `npm run validate` and `npm run zip` |
+| Selector change | Automated checks plus manual target-site verification |
+| Visible UI change | Firefox and Chromium smoke test; Android when practical |
+
+There is no comprehensive DOM or end-to-end suite yet. Do not treat passing
+unit tests as proof that current social-network selectors work.
+
+## Contribution and release workflow
+
+- Keep pull requests focused and use Conventional Commit titles.
+- Squash merges make the PR title the commit message consumed by Release
+  Please.
+- Required CI check: `Validate and package`.
+- Merges are controlled by the maintainer. The single-maintainer ruleset does
+  not require a separate approval, but CI and resolved conversations remain
+  mandatory.
+- `CODEOWNERS` currently assigns the repository to `@arturosdg`.
+- Dependabot separates patch, minor and major npm updates and applies cooldowns;
+  security updates must not be intentionally delayed.
+
+### Pull request targets and dependent changes
+
+The default and only integration branch is `main`. Every pull request must use
+`main` as its base, including changes that depend on another open pull request.
+Never target a temporary feature branch: merging such a PR would update that
+branch instead of `main` and would not start the release workflow.
+
+For dependent changes:
+
+1. Create each change on top of its logical predecessor, but open every PR
+   against `main`.
+2. State the dependency and required merge order in the PR body.
+3. Accept that later PRs show a cumulative diff until their predecessors land.
+4. After a predecessor is merged, fetch `origin/main`, rebase the next branch
+   onto it and push with `--force-with-lease`.
+5. Confirm that GitHub now shows only the intended commit(s), the base is
+   `main`, and required checks pass again.
+6. Merge in dependency order.
+
+Agents may create commits, push branches and maintain draft PRs. They must not
+mark a PR ready, enable auto-merge or merge a PR unless the maintainer
+explicitly requests that action in the current task.
+
+Release Please opens a version PR after releasable commits reach `main`.
+Creating that PR with `GITHUB_TOKEN` requires the repository setting that lets
+Actions create pull requests. For unattended downstream CI, prefer a narrowly
+scoped `RELEASE_PLEASE_TOKEN` or GitHub App token. AMO publishing is optional
+and requires the three Firefox secrets documented in `README.md`.
+
+### Commit convention
+
+Use this shape for commits and PR titles:
+
+```text
+<type>(<optional-scope>): <imperative summary>
+```
+
+Rules:
+
+- Use a lowercase type and scope.
+- Write a concise, imperative summary without a trailing period.
+- Keep one logical change per commit.
+- Use the body to explain motivation, trade-offs or migration details when the
+  summary is not enough.
+- Mark breaking changes with `!`, for example `feat(storage)!: replace daily
+  state schema`, and add a `BREAKING CHANGE:` footer explaining the impact.
+- Before committing, check that the staged diff contains only the intended
+  change and run the validation required by the testing matrix.
+
+Project commit types:
+
+| Type | Use |
+| --- | --- |
+| `feat` | New user-visible behavior; produces a minor release |
+| `fix` | User-visible defect correction; produces a patch release |
+| `docs` | Documentation only |
+| `test` | Tests without a behavior change |
+| `refactor` | Internal restructuring without a behavior change |
+| `perf` | Performance improvement |
+| `build` | Build system or packaging |
+| `ci` | CI/CD workflow or automation |
+| `chore` | Repository maintenance not covered above |
+| `deps` | Dependency-only updates, including Dependabot |
+
+`feat!`, `fix!` or any commit with a `BREAKING CHANGE:` footer produces a major
+release. The non-release types above do not normally create a Release Please
+version bump.
+
+Examples:
+
+```text
+feat(timer): add a per-network daily ceiling
+fix(instagram): avoid limiting profile routes
+docs: document selector verification
+ci(release): upload browser packages
+deps(deps-dev): bump the TypeScript toolchain
+```
+
+Dependabot is configured to use `deps` plus the dependency scope, yielding
+titles such as `deps(deps): ...` and `deps(deps-dev): ...`. Preserve that format
+when editing `.github/dependabot.yml`.
+
+## Definition of done
+
+Before completing a change:
+
+1. Review the diff for unrelated edits and generated files.
+2. Confirm product scope, privacy and permissions remain intentional.
+3. Add or update tests and documentation proportional to the change.
+4. Run the required validation from the matrix above.
+5. Report manual testing gaps honestly, especially selector-dependent behavior.
+6. Note any state migration, browser compatibility or release impact.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,21 @@ The pull request template includes the expected validation, privacy and
 documentation checks. Items that do not apply can be left unchecked with a
 short explanation.
 
+## Pull request targets and dependencies
+
+All pull requests target `main`, the repository's integration and release
+branch. Do not use another feature branch as the PR base.
+
+When one change depends on another open PR, build its branch on top of the
+predecessor but still target `main`. Document the dependency and merge order in
+the PR body. The child PR will temporarily show a cumulative diff. After the
+predecessor is merged, rebase the child branch onto the latest `main`, push it
+with `--force-with-lease` and verify that its focused diff and CI checks are
+correct before merging.
+
+Pull requests are opened as drafts by automation. The maintainer decides when
+they are ready and performs every merge.
+
 ## Releases
 
 Release Please maintains the release pull request, `CHANGELOG.md`,

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -8,6 +8,7 @@ Keep the useful parts of social networks while giving every feed a real end.
 
 - Firefox for Android
 - Reddit, X and Instagram mobile websites
+- English-language application interface
 - Authenticated browser sessions, including private content the user is already
   authorized to see
 

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -1,19 +1,19 @@
 <!doctype html>
-<html lang="es">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Dopamine Fast — Ajustes</title>
+    <title>Dopamine Fast — Settings</title>
     <script type="module" src="./main.ts"></script>
   </head>
   <body>
     <main class="settings-shell">
       <header class="hero">
-        <p class="eyebrow">Dopamine Fast / Ajustes locales</p>
-        <h1>Haz que el feed<br />tenga un final.</h1>
+        <p class="eyebrow">Dopamine Fast / Local settings</p>
+        <h1>Give your feed<br />a real ending.</h1>
         <p class="hero-copy">
-          Estos límites viven solo en tu navegador. No analizamos ni enviamos
-          el contenido que ves.
+          These limits live only in your browser. We do not analyze or send
+          the content you see.
         </p>
       </header>
 
@@ -21,8 +21,8 @@
         <section class="panel panel--status">
           <label class="master-toggle">
             <span>
-              <strong>Protección activa</strong>
-              <small>Pausa y limita los feeds compatibles.</small>
+              <strong>Protection enabled</strong>
+              <small>Pause and limit supported feeds.</small>
             </span>
             <input id="enabled" name="enabled" type="checkbox" />
             <span class="switch" aria-hidden="true"></span>
@@ -32,16 +32,16 @@
         <section class="panel">
           <div class="section-number">01</div>
           <div class="section-heading">
-            <h2>Tiempo consciente</h2>
+            <h2>Intentional time</h2>
             <p>
-              Elige una intención por sesión y un techo diario que no se puede
-              desbloquear.
+              Choose an intention for each session and a daily ceiling that
+              cannot be unlocked.
             </p>
           </div>
 
           <div class="number-grid number-grid--two">
             <label class="number-field">
-              <span>Sesión sugerida</span>
+              <span>Suggested session</span>
               <input
                 id="session-duration"
                 name="sessionDurationMinutes"
@@ -50,11 +50,11 @@
                 max="60"
                 step="1"
               />
-              <small>minutos, ajustables al entrar</small>
+              <small>minutes, adjustable when entering</small>
             </label>
 
             <label class="number-field">
-              <span>Máximo diario por red</span>
+              <span>Daily maximum per network</span>
               <input
                 id="daily-usage-limit"
                 name="dailyUsageLimitMinutes"
@@ -63,7 +63,7 @@
                 max="240"
                 step="5"
               />
-              <small>minutos, fijo hasta mañana</small>
+              <small>minutes, fixed until tomorrow</small>
             </label>
           </div>
         </section>
@@ -71,12 +71,12 @@
         <section class="panel">
           <div class="section-number">02</div>
           <div class="section-heading">
-            <h2>Ritmo de entrada</h2>
-            <p>Introduce una pausa antes de abrir un feed.</p>
+            <h2>Entry pace</h2>
+            <p>Add a pause before opening a feed.</p>
           </div>
 
           <label class="field">
-            <span>Pausa al entrar</span>
+            <span>Pause before entering</span>
             <output id="opening-delay-output" for="opening-delay"></output>
             <input
               id="opening-delay"
@@ -89,7 +89,7 @@
           </label>
 
           <label class="field">
-            <span>Espera antes de desbloquear</span>
+            <span>Wait before unlocking</span>
             <output id="unlock-delay-output" for="unlock-delay"></output>
             <input
               id="unlock-delay"
@@ -105,13 +105,13 @@
         <section class="panel">
           <div class="section-number">03</div>
           <div class="section-heading">
-            <h2>Tamaño del feed</h2>
-            <p>Cada lote termina de verdad. Tú decides si abres otro.</p>
+            <h2>Feed size</h2>
+            <p>Every batch truly ends. You decide whether to open another.</p>
           </div>
 
           <div class="number-grid">
             <label class="number-field">
-              <span>Primer lote</span>
+              <span>First batch</span>
               <input
                 id="batch-size"
                 name="batchSize"
@@ -120,11 +120,11 @@
                 max="100"
                 step="5"
               />
-              <small>publicaciones</small>
+              <small>posts</small>
             </label>
 
             <label class="number-field">
-              <span>Lotes extra</span>
+              <span>Extra batches</span>
               <input
                 id="unlock-batch-size"
                 name="unlockBatchSize"
@@ -133,11 +133,11 @@
                 max="50"
                 step="5"
               />
-              <small>publicaciones</small>
+              <small>posts</small>
             </label>
 
             <label class="number-field">
-              <span>Máximo diario</span>
+              <span>Daily maximum</span>
               <input
                 id="daily-limit"
                 name="dailyLimit"
@@ -146,7 +146,7 @@
                 max="500"
                 step="10"
               />
-              <small>entre todas las redes</small>
+              <small>across all networks</small>
             </label>
           </div>
         </section>
@@ -154,36 +154,36 @@
         <section class="panel">
           <div class="section-number">04</div>
           <div class="section-heading">
-            <h2>Fricción</h2>
-            <p>Cuánto cuesta elegir conscientemente otro lote.</p>
+            <h2>Friction</h2>
+            <p>How much effort it takes to intentionally choose another batch.</p>
           </div>
 
           <div class="mode-grid">
             <label class="mode-card">
               <input type="radio" name="mode" value="gentle" />
               <span>
-                <strong>Suave</strong>
-                <small>Lotes extra sin máximo de desbloqueos.</small>
+                <strong>Gentle</strong>
+                <small>Extra batches without an unlock limit.</small>
               </span>
             </label>
             <label class="mode-card">
               <input type="radio" name="mode" value="balanced" />
               <span>
-                <strong>Equilibrado</strong>
-                <small>Hasta dos desbloqueos por día.</small>
+                <strong>Balanced</strong>
+                <small>Up to two unlocks per day.</small>
               </span>
             </label>
             <label class="mode-card">
               <input type="radio" name="mode" value="strict" />
               <span>
-                <strong>Estricto</strong>
-                <small>El máximo diario manda.</small>
+                <strong>Strict</strong>
+                <small>The daily maximum always applies.</small>
               </span>
             </label>
           </div>
 
           <label class="field">
-            <span>Mantener pulsado</span>
+            <span>Press-and-hold time</span>
             <output id="hold-output" for="hold-seconds"></output>
             <input
               id="hold-seconds"
@@ -199,16 +199,16 @@
         <section class="panel">
           <div class="section-number">05</div>
           <div class="section-heading">
-            <h2>Redes y ruido</h2>
-            <p>La detección es inicial: afinaremos selectores al probarla.</p>
+            <h2>Networks and noise</h2>
+            <p>Detection is an early version; selectors will evolve with testing.</p>
           </div>
 
           <div class="toggle-list">
             <label><span>Reddit</span><input id="site-reddit" type="checkbox" /></label>
             <label><span>X / Twitter</span><input id="site-x" type="checkbox" /></label>
             <label><span>Instagram</span><input id="site-instagram" type="checkbox" /></label>
-            <label><span>Ocultar sugerencias</span><input id="block-suggested" type="checkbox" /></label>
-            <label><span>Detener reproducción automática</span><input id="disable-autoplay" type="checkbox" /></label>
+            <label><span>Hide suggestions</span><input id="block-suggested" type="checkbox" /></label>
+            <label><span>Stop autoplay</span><input id="disable-autoplay" type="checkbox" /></label>
           </div>
         </section>
 
@@ -216,10 +216,10 @@
           <p id="save-status" role="status" aria-live="polite"></p>
           <div>
             <button class="button button--quiet" id="reset-day" type="button">
-              Reiniciar publicaciones de hoy
+              Reset today's post count
             </button>
             <button class="button button--primary" type="submit">
-              Guardar cambios
+              Save changes
             </button>
           </div>
         </footer>

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -105,7 +105,7 @@ form.addEventListener("submit", async (event) => {
   event.preventDefault();
   await saveSettings(readSettings());
   status.textContent =
-    "Guardado. Si hoy ya usaste una red, su nuevo techo se aplica mañana.";
+    "Saved. If you already used a network today, its new ceiling applies tomorrow.";
   window.setTimeout(() => {
     status.textContent = "";
   }, 2400);
@@ -115,7 +115,7 @@ requiredElement<HTMLButtonElement>("#reset-day").addEventListener(
   "click",
   async () => {
     await resetDailyState();
-    status.textContent = "El contador de publicaciones vuelve a cero.";
+    status.textContent = "Today's post count has been reset.";
   },
 );
 

--- a/lib/intervention-ui.ts
+++ b/lib/intervention-ui.ts
@@ -28,10 +28,10 @@ export interface SessionEndedOptions {
 }
 
 const intentions = [
-  ["specific", "Busco algo concreto"],
-  ["reply", "Quiero responder o interactuar"],
-  ["deliberate", "Quiero seguir leyendo"],
-  ["automatic", "Estoy bajando por inercia"],
+  ["specific", "I'm looking for something specific"],
+  ["reply", "I want to reply or interact"],
+  ["deliberate", "I want to keep reading"],
+  ["automatic", "I'm scrolling on autopilot"],
 ] as const;
 
 export class InterventionUi {
@@ -80,18 +80,18 @@ export class InterventionUi {
     this.overlay.innerHTML = `
       <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-opening-title">
         <article class="df-card df-card--opening">
-          <p class="df-kicker">Una pausa antes de entrar</p>
+          <p class="df-kicker">A pause before entering</p>
           ${
             options.delaySeconds > 0
               ? `<div class="df-countdown" aria-live="polite">${options.delaySeconds}</div>`
               : `<div class="df-pause-mark df-pause-mark--centered" aria-hidden="true"></div>`
           }
-          <h1 id="df-opening-title">¿Cuánto tiempo quieres dedicar a ${options.platformLabel}?</h1>
+          <h1 id="df-opening-title">How much time do you want to spend on ${options.platformLabel}?</h1>
           <p class="df-copy">
-            Elige ahora una sesión concreta. El contador seguirá visible mientras navegas.
+            Choose a defined session now. The timer will remain visible as you browse.
           </p>
           <label class="df-time-choice">
-            <span>Esta sesión</span>
+            <span>This session</span>
             <output for="df-session-minutes">${defaultSessionLabel}</output>
             <input
               id="df-session-minutes"
@@ -104,20 +104,20 @@ export class InterventionUi {
             />
           </label>
           <p class="df-hard-limit-note">
-            Quedan <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong>
-            del límite diario de esta red.
+            You have <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong>
+            left in today's limit for this network.
           </p>
           <div class="df-actions">
-            <button class="df-button df-button--quiet" data-action="leave">Salir</button>
+            <button class="df-button df-button--quiet" data-action="leave">Leave</button>
             <button class="df-button df-button--primary" data-action="continue" disabled>
               ${
                 options.delaySeconds > 0
-                  ? `Continuar en ${options.delaySeconds}s`
-                  : `Entrar ${defaultSessionLabel}`
+                  ? `Continue in ${options.delaySeconds}s`
+                  : `Start ${defaultSessionLabel} session`
               }
             </button>
           </div>
-          <button class="df-settings-link" data-action="settings">Ajustar tiempos y límites</button>
+          <button class="df-settings-link" data-action="settings">Adjust time and limits</button>
         </article>
       </section>
     `;
@@ -144,7 +144,7 @@ export class InterventionUi {
         options.availableSeconds < 60 ? "<1 min" : `${sessionInput.value} min`;
       sessionOutput.value = label;
       if (!continueButton.disabled) {
-        continueButton.textContent = `Entrar ${label}`;
+        continueButton.textContent = `Start ${label} session`;
       }
     });
 
@@ -163,12 +163,12 @@ export class InterventionUi {
           if (countdown) countdown.textContent = String(Math.max(0, remaining));
           continueButton.textContent =
             remaining > 0
-              ? `Continuar en ${remaining}s`
-              : `Entrar ${
+              ? `Continue in ${remaining}s`
+              : `Start ${
                   options.availableSeconds < 60
                     ? "<1 min"
                     : `${sessionInput.value} min`
-                }`;
+                } session`;
 
           if (remaining <= 0) {
             if (interval !== undefined) window.clearInterval(interval);
@@ -196,22 +196,22 @@ export class InterventionUi {
       <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-end-title">
         <article class="df-card">
           <div class="df-rule"></div>
-          <p class="df-kicker">Fin del lote</p>
-          <h1 id="df-end-title">Ya has terminado por ahora.</h1>
+          <p class="df-kicker">End of batch</p>
+          <h1 id="df-end-title">That's enough for now.</h1>
           <p class="df-copy">
             ${options.remainingToday > 0
-              ? `Quedan ${options.remainingToday} publicaciones en tu límite de hoy.`
-              : "Has alcanzado tu límite diario."}
+              ? `You have ${options.remainingToday} posts left in today's limit.`
+              : "You've reached today's limit."}
           </p>
           <div class="df-actions df-actions--stack">
-            <button class="df-button df-button--primary" data-action="leave">Salir de ${options.platformLabel}</button>
+            <button class="df-button df-button--primary" data-action="leave">Leave ${options.platformLabel}</button>
             ${
               options.canUnlock
-                ? `<button class="df-button df-button--quiet" data-action="unlock">Desbloquear ${options.unlockSize} más</button>`
+                ? `<button class="df-button df-button--quiet" data-action="unlock">Unlock ${options.unlockSize} more</button>`
                 : ""
             }
           </div>
-          <button class="df-settings-link" data-action="settings">Cambiar límites</button>
+          <button class="df-settings-link" data-action="settings">Change limits</button>
         </article>
       </section>
     `;
@@ -241,13 +241,13 @@ export class InterventionUi {
       <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-session-end-title">
         <article class="df-card">
           <div class="df-rule"></div>
-          <p class="df-kicker">Tiempo elegido completado</p>
-          <h1 id="df-session-end-title">Tu sesión ya terminó.</h1>
+          <p class="df-kicker">Planned time complete</p>
+          <h1 id="df-session-end-title">Your session has ended.</h1>
           <p class="df-copy">
-            Elegiste parar aquí. Si todavía tienes un motivo concreto, puedes planear otro bloque.
+            You chose to stop here. If you still have a specific reason, you can plan another block.
           </p>
           <label class="df-time-choice">
-            <span>Nuevo bloque</span>
+            <span>New block</span>
             <output for="df-extra-minutes">${defaultSessionLabel}</output>
             <input
               id="df-extra-minutes"
@@ -260,14 +260,14 @@ export class InterventionUi {
             />
           </label>
           <p class="df-hard-limit-note">
-            El techo diario no se puede ampliar:
-            <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong> disponibles.
+            Your daily ceiling cannot be extended:
+            <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong> remaining.
           </p>
           <div class="df-actions">
-            <button class="df-button df-button--primary" data-action="leave">Salir de ${options.platformLabel}</button>
-            <button class="df-button df-button--quiet" data-action="extend">Planear otro bloque</button>
+            <button class="df-button df-button--primary" data-action="leave">Leave ${options.platformLabel}</button>
+            <button class="df-button df-button--quiet" data-action="extend">Plan another block</button>
           </div>
-          <button class="df-settings-link" data-action="settings">Cambiar el valor predeterminado</button>
+          <button class="df-settings-link" data-action="settings">Change the default</button>
         </article>
       </section>
     `;
@@ -308,15 +308,15 @@ export class InterventionUi {
       <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-hard-limit-title">
         <article class="df-card">
           <div class="df-lock-mark" aria-hidden="true"></div>
-          <p class="df-kicker">Límite diario completado</p>
-          <h1 id="df-hard-limit-title">${platformLabel} termina aquí por hoy.</h1>
+          <p class="df-kicker">Daily limit reached</p>
+          <h1 id="df-hard-limit-title">${platformLabel} ends here for today.</h1>
           <p class="df-copy">
-            Este límite no tiene desbloqueo. Volverá a estar disponible mañana.
+            This limit cannot be unlocked. It will be available again tomorrow.
           </p>
           <div class="df-actions df-actions--stack">
-            <button class="df-button df-button--primary" data-action="leave">Salir de ${platformLabel}</button>
+            <button class="df-button df-button--primary" data-action="leave">Leave ${platformLabel}</button>
           </div>
-          <button class="df-settings-link" data-action="settings">Ver configuración</button>
+          <button class="df-settings-link" data-action="settings">View settings</button>
         </article>
       </section>
     `;
@@ -330,11 +330,11 @@ export class InterventionUi {
   showUsageTimer(options: UsageTimerOptions): void {
     if (this.timer.childElementCount === 0) {
       this.timer.innerHTML = `
-        <button class="df-usage-timer" type="button" title="Abrir los ajustes de Dopamine Fast">
+        <button class="df-usage-timer" type="button" title="Open Dopamine Fast settings">
           <span class="df-usage-timer__pulse" aria-hidden="true"></span>
           <span class="df-usage-timer__copy">
             <strong data-timer="planned"></strong>
-            <small><span data-timer="platform"></span> · <span data-timer="daily"></span> hoy</small>
+            <small><span data-timer="platform"></span> · <span data-timer="daily"></span> today</small>
           </span>
         </button>
       `;
@@ -360,7 +360,7 @@ export class InterventionUi {
         : "false";
     timer.setAttribute(
       "aria-label",
-      `${this.formatClock(options.plannedSeconds)} de sesión; ${this.formatFriendlyDuration(options.availableSeconds)} disponibles hoy en ${options.platformLabel}`,
+      `${this.formatClock(options.plannedSeconds)} left in this session; ${this.formatFriendlyDuration(options.availableSeconds)} available today on ${options.platformLabel}`,
     );
   }
 
@@ -371,8 +371,8 @@ export class InterventionUi {
   private showIntentionStep(options: EndOfBatchOptions): void {
     const card = this.requiredElement<HTMLElement>(".df-card");
     card.innerHTML = `
-      <p class="df-step">Paso 1 de 2</p>
-      <h1>¿Para qué quieres continuar?</h1>
+      <p class="df-step">Step 1 of 2</p>
+      <h1>Why do you want to continue?</h1>
       <div class="df-intentions">
         ${intentions
           .map(
@@ -384,7 +384,7 @@ export class InterventionUi {
           )
           .join("")}
       </div>
-      <button class="df-settings-link" data-action="back">Volver</button>
+      <button class="df-settings-link" data-action="back">Back</button>
     `;
 
     card
@@ -399,16 +399,16 @@ export class InterventionUi {
   private showHoldStep(options: EndOfBatchOptions): void {
     const card = this.requiredElement<HTMLElement>(".df-card");
     card.innerHTML = `
-      <p class="df-step">Paso 2 de 2</p>
+      <p class="df-step">Step 2 of 2</p>
       <div class="df-pause-mark" aria-hidden="true"></div>
-      <h1>Espera un momento.</h1>
-      <p class="df-copy">Después mantén pulsado para abrir otro lote.</p>
+      <h1>Pause for a moment.</h1>
+      <p class="df-copy">Then press and hold to open another batch.</p>
       <button class="df-hold" data-action="hold" disabled style="--df-hold-progress: 0%">
-        <span>Mantén pulsado</span>
+        <span>Press and hold</span>
         <span class="df-hold__progress" aria-hidden="true"></span>
       </button>
       <p class="df-wait" aria-live="polite"></p>
-      <button class="df-settings-link" data-action="back">Volver</button>
+      <button class="df-settings-link" data-action="back">Back</button>
     `;
 
     const holdButton =
@@ -418,7 +418,7 @@ export class InterventionUi {
 
     const updateWait = () => {
       waitLabel.textContent =
-        remaining > 0 ? `Disponible en ${remaining}s` : "Cuando quieras.";
+        remaining > 0 ? `Available in ${remaining}s` : "Whenever you're ready.";
     };
     updateWait();
 
@@ -453,7 +453,7 @@ export class InterventionUi {
       if (progress >= 1) {
         completed = true;
         holdButton.disabled = true;
-        holdButton.querySelector("span")!.textContent = "Preparando…";
+        holdButton.querySelector("span")!.textContent = "Preparing…";
         const granted = await options.onUnlock();
         if (granted > 0) {
           this.hide();


### PR DESCRIPTION
## Delivery order

This PR targets `main` directly and depends on #23. Merge #23 first; until then this PR's diff also contains the English-interface commit. After #23 lands, GitHub will reduce this PR to its own agent-guidance commit automatically.

## What changed

- Added a root-level `AGENTS.md` as the canonical instruction source for coding agents and contributors.
- Added `CLAUDE.md` with the official `@AGENTS.md` import so Claude Code and Codex consume the same guidance without duplicated copies.
- Documented product intent, architecture, module boundaries, state invariants, privacy, security and code-review rules.
- Added a complete Conventional Commits policy with allowed types, release semantics and examples.
- Configured Dependabot to emit Conventional Commit titles for regular and development dependencies: `deps(deps): ...` and `deps(deps-dev): ...`.
- Defined the dependent-PR workflow: every PR targets `main`, dependencies are documented, child branches are rebased after predecessors merge and only the maintainer controls readiness and merges.
- Added the `main` target check to the pull request template and documented the same workflow in `CONTRIBUTING.md`.
- Recorded the validation matrix, definition of done and known architectural gaps.

## Architectural findings captured

- Concurrent content-script storage writes can lose usage increments and should eventually move behind a serialized background owner.
- `intervention-ui.ts` should be split before adding substantial new flows.
- Selector-dependent behavior still needs DOM fixtures and manual browser testing.
- Strict mode does not yet implement every fail-closed behavior in the product specification.

## Validation

- `git diff --check`
- Parsed `.github/dependabot.yml` successfully as YAML
- Verified referenced package scripts and repository documents exist
- `AGENTS.md` remains below Codex's default 32 KiB project-instruction limit