### PR TITLE
fix: enforce deliberate session and feed limits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,7 @@ pin third-party GitHub Actions to full commit SHAs.
 
 ```text
 entrypoints/
+  background.ts          Serialized owner for daily-state mutations and privileged navigation
   content.ts             Runtime composition root for supported pages
   options/
     index.html           Settings markup
@@ -123,9 +124,13 @@ lib/
   models.ts              Domain types, defaults, sanitization and pure rules
   storage.ts             WXT storage keys and persistence operations
   platforms.ts           Host/route detection and selector adapters
+  batch-gate-ui.ts       Inline end-of-batch control rendered inside the native feed
   feed-limiter.ts        DOM observation, post visibility and batch boundaries
   usage-session.ts       Visible-tab session timer and persistence lifecycle
   intervention-ui.ts     Shadow-DOM overlays, timer and deliberate interactions
+  runtime-messages.ts    Validated background/content message contracts
+  serial-queue.ts        Promise queue used by the background state owner
+  session-time.ts        Pure discrete time-choice construction
 assets/content.css       Injected shadow-root presentation
 tests/                   Vitest unit tests for pure domain/platform behavior
 public/                  Extension icons copied by WXT
@@ -155,14 +160,19 @@ Specific responsibilities:
 - `entrypoints/content.ts` composes services, reacts to SPA navigation/settings
   changes and owns activation cancellation. Keep policy and DOM algorithms out
   of it.
+- `entrypoints/background.ts` is the single owner for daily post/time mutations
+  and privileged options/leave navigation. Keep its message surface validated
+  and route new daily-state writes through its serialized queue.
 - `models.ts` must remain deterministic and easy to unit test. Put defaults,
   clamps, date normalization and pure budget calculations here.
 - `storage.ts` owns storage key names and all persistent reads/writes. Other
   modules must not introduce ad-hoc storage keys.
 - `platforms.ts` is the only home for network-specific hosts, feed routes,
-  selectors and recommendation markers.
+  selectors, stable post identities and recommendation markers.
 - `feed-limiter.ts` may manipulate feed elements, but it must restore every
   style it changes when destroyed.
+- `batch-gate-ui.ts` owns the inline end-of-batch control and must remain
+  isolated from host-page styles and text.
 - `usage-session.ts` owns timer state and persistence cadence, not overlay
   markup.
 - `intervention-ui.ts` owns rendering and direct UI interaction, not storage or
@@ -189,12 +199,11 @@ Preserve these invariants:
 - Repeated activation must cancel stale asynchronous UI results.
 - Teardown must clear timers, observers and listeners and restore page state.
 
-Important known limitation: `storage.ts` currently performs read-modify-write
-updates from content scripts. Two active tabs can race and lose post
-reservations or elapsed-time increments. Before describing daily ceilings as
-reliable across concurrent tabs, route mutations through one background owner
-(or another serialized transaction mechanism) and add multi-tab tests. This is
-the highest-priority architectural hardening.
+Daily post reservations, elapsed-time increments and post-counter resets are
+serialized through the background owner. Content scripts watch persisted time
+usage and lower their local remaining-time view when another tab advances it.
+Preserve this ownership model and add browser-level multi-tab coverage when an
+end-to-end harness is introduced.
 
 ## Platform adapter changes
 
@@ -232,6 +241,8 @@ Treat the host page as untrusted input:
 - Page locks must restore the original `html` and `body` overflow values.
 - Observers and DOM scans must be debounced and bounded; social feeds mutate
   continuously.
+- Virtualized feeds must count stable post identities in memory so removing old
+  DOM nodes cannot reopen the current batch. Do not persist those identities.
 
 A “hard” limit means no bypass exposed by the extension UI. Users still control
 their browser, storage and installed extensions; documentation must not imply

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -20,40 +20,42 @@ Keep the useful parts of social networks while giving every feed a real end.
 4. A floating countdown remains visible while the supported feed is active.
 5. Dopamine Fast removes promoted and suggested content.
 6. The first 20 top-level post elements remain visible.
-7. The native feed is covered by an end-of-batch barrier after the twentieth
-   post.
-8. The user can leave or deliberately unlock 10 additional posts.
+7. The native feed ends with an inline load-more control after the twentieth
+   post; no full-screen intervention is shown for a batch boundary.
+8. The user can deliberately reveal 10 additional posts from that control.
 9. Daily hard limits for both time and posts stop further use.
 
 ## Time budgets
 
 - Before entry, the user selects an intentional session duration.
+- Session duration changes use discrete buttons instead of a slider, so adding
+  more time requires a separate deliberate press for each step.
 - The configured default is 10 minutes and can be adjusted from 1 to 60
   minutes at entry.
 - A compact floating counter shows the planned session time and the remaining
   daily time for the current network.
 - Time advances only while the tab is visible.
 - When planned time ends, the user can leave or deliberately plan another
-  block.
+  block after a 10-second pause. The next duration cannot be selected until
+  that pause has completed.
+- Leaving an intervention replaces the current social-feed tab with a blank
+  tab instead of relying on browser history.
 - A separate daily limit applies to each supported network. It persists across
   reloads and sessions, resets on the next local calendar day and has no
   in-page unlock.
+- Daily post and time mutations are serialized by the extension background
+  context, and active tabs reconcile against persisted usage from other tabs.
 - The effective ceiling is fixed for the day. Configuration changes apply on
   the next local calendar day, and the settings page cannot reset elapsed time.
 
 ## Unlock flow
 
-The balanced-mode unlock requires:
-
-1. Selecting an intention:
-   - Find something specific
-   - Reply or interact
-   - Continue reading deliberately
-   - I am scrolling automatically
-2. Waiting through a short pause.
-3. Holding the unlock control for three seconds.
-
-The answers are stored only as aggregate local counts and are never transmitted.
+The end of a batch is rendered inside the native feed. The inline control shows
+how many posts remain in the daily allowance, waits through the configured
+pause and requires holding the load-more button for the configured duration.
+Completing it reveals only the next configured batch.
+Virtualized feeds are counted by stable post identity for the active page
+session, so recycling DOM elements cannot reset the batch.
 
 ## Modes
 
@@ -66,7 +68,7 @@ The answers are stored only as aggregate local counts and are never transmitted.
 ### Balanced
 
 - One initial batch and two additional batches.
-- Intent selection, pause and hold are required.
+- The inline pause and hold are required.
 
 ### Strict
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ available while adding deliberate friction around habitual scrolling:
 2. You choose an intended session length before entering.
 3. A floating timer keeps that decision visible while you browse.
 4. Posts are revealed in finite batches instead of an endless stream.
-5. Reaching the end requires a deliberate multi-step unlock.
+5. Reaching the end shows an inline control for loading the next batch.
 6. A per-network daily time ceiling cannot be extended from the page.
 
 Daily post allowances are shared across supported networks. Daily time
@@ -34,30 +34,19 @@ Preferences and aggregate counters stay in browser extension local storage.
 ## Product tour
 
 The opening pause asks for a concrete time intention before the feed becomes
-available. The batch boundary then creates a real stopping point instead of
-loading more posts automatically.
+available. At the batch boundary, the feed ends with an inline button instead
+of loading more posts automatically.
 
-<table>
-  <tr>
-    <td width="50%">
-      <img src="docs/screenshots/opening-pause.png" alt="Opening pause on a mobile feed" />
-    </td>
-    <td width="50%">
-      <img src="docs/screenshots/end-of-batch.png" alt="End-of-batch intervention on a mobile feed" />
-    </td>
-  </tr>
-  <tr>
-    <td align="center"><strong>Choose the session before entering</strong></td>
-    <td align="center"><strong>Stop or deliberately unlock another batch</strong></td>
-  </tr>
-</table>
+![Opening pause on a mobile feed](docs/screenshots/opening-pause.png)
 
 ## Features
 
 - Configurable delay before entering a supported feed.
-- Intentional session duration with a persistent floating countdown.
+- Intentional session duration, adjusted through deliberate button steps, with
+  a persistent floating countdown.
 - Non-extendable daily time ceiling for each network.
 - Finite initial and additional post batches.
+- Stable per-session post counting for virtualized feeds such as Reddit.
 - Optional delay and press-and-hold step before revealing another batch.
 - Gentle, balanced, and strict friction modes.
 - Best-effort suppression of suggested and promoted surfaces.
@@ -122,18 +111,23 @@ entrypoints/content.ts
        ├─ platform selectors
        ├─ finite batches
        ├─ suggested-content suppression
-       └─ unlock interventions
+       └─ inline load-more gate
+
+entrypoints/background.ts
+  └─ serialized daily post and time mutations
 
 entrypoints/options/
   └─ local settings UI
 
 lib/
+  ├─ batch-gate-ui.ts
   ├─ models.ts
   ├─ storage.ts
   ├─ platforms.ts
   ├─ feed-limiter.ts
   ├─ usage-session.ts
-  └─ intervention-ui.ts
+  ├─ intervention-ui.ts
+  └─ session-time.ts
 ```
 
 The content script is injected only on supported hosts. Its interface runs in
@@ -164,8 +158,8 @@ installed software.
 
 - Social-network selectors are inherently fragile and need ongoing manual
   verification.
-- Concurrent tabs can race while updating local daily counters; serializing
-  those writes is the highest-priority state-hardening task.
+- Active tabs reconcile their daily time counters whenever the background
+  owner persists usage from any supported tab.
 - Gentle and strict modes do not yet differ as much as the complete product
   specification intends.
 - There is not yet a published browser-store installation.

--- a/assets/content.css
+++ b/assets/content.css
@@ -1,10 +1,10 @@
 :host {
-  --df-paper: #f3efe4;
-  --df-ink: #172018;
-  --df-accent: #ccff00;
-  --df-muted: #687067;
-  --df-line: rgba(23, 32, 24, 0.22);
-  color-scheme: light;
+  --df-paper: #151716;
+  --df-ink: #f0f1ed;
+  --df-accent: #929a94;
+  --df-muted: #a5aaa6;
+  --df-line: rgba(240, 241, 237, 0.2);
+  color-scheme: dark;
 }
 
 .df-root {
@@ -31,31 +31,31 @@
   z-index: 2147483647;
   inset: 0;
   display: grid;
-  align-items: end;
-  padding: 14px;
-  background:
-    linear-gradient(180deg, rgba(16, 20, 16, 0.42), rgba(16, 20, 16, 0.78)),
-    repeating-linear-gradient(
-      135deg,
-      rgba(255, 255, 255, 0.018) 0,
-      rgba(255, 255, 255, 0.018) 1px,
-      transparent 1px,
-      transparent 7px
-    );
+  align-items: stretch;
+  padding: 0;
+  background: #111312;
   box-sizing: border-box;
   animation: df-backdrop-in 180ms ease-out both;
 }
 
 .df-card {
   position: relative;
-  overflow: hidden;
-  width: min(100%, 520px);
+  display: flex;
+  overflow-y: auto;
+  width: 100%;
+  min-height: 100%;
+  flex-direction: column;
+  justify-content: center;
   margin: 0 auto;
-  padding: 30px 24px 20px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  border-radius: 2px;
+  padding:
+    max(36px, env(safe-area-inset-top))
+    max(24px, env(safe-area-inset-right))
+    max(28px, env(safe-area-inset-bottom))
+    max(24px, env(safe-area-inset-left));
+  border: 0;
+  border-radius: 0;
   background: var(--df-paper);
-  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.3);
+  box-shadow: none;
   box-sizing: border-box;
   animation: df-card-in 260ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
 }
@@ -75,8 +75,7 @@
   line-height: 0.98;
 }
 
-.df-kicker,
-.df-step {
+.df-kicker {
   margin: 0 0 16px;
   color: var(--df-muted);
   font-size: 11px;
@@ -100,7 +99,7 @@
   place-items: center;
   border: 1px solid var(--df-ink);
   border-radius: 50%;
-  background: var(--df-accent);
+  background: transparent;
   font-family: "Iowan Old Style", "Palatino Linotype", serif;
   font-size: 42px;
   font-variant-numeric: tabular-nums;
@@ -114,7 +113,7 @@
   margin: 20px auto 0;
   padding: 14px 16px;
   border: 1px solid var(--df-line);
-  background: rgba(255, 255, 255, 0.34);
+  background: rgba(255, 255, 255, 0.025);
   color: var(--df-ink);
   font-size: 13px;
   font-weight: 800;
@@ -128,10 +127,29 @@
   font-weight: 600;
 }
 
-.df-time-choice input {
+.df-time-buttons {
   grid-column: 1 / -1;
-  width: 100%;
-  accent-color: var(--df-ink);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.df-time-buttons button {
+  min-height: 46px;
+  padding: 10px 14px;
+  border: 1px solid var(--df-line);
+  color: var(--df-ink);
+  background: transparent;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.df-time-buttons button:disabled {
+  cursor: default;
+  opacity: 0.35;
 }
 
 .df-hard-limit-note {
@@ -151,14 +169,16 @@
   height: 8px;
   margin-bottom: 26px;
   background: var(--df-accent);
-  box-shadow: 14px 0 0 var(--df-ink);
+  box-shadow: none;
 }
 
 .df-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 10px;
-  margin-top: 24px;
+  width: 100%;
+  max-width: 390px;
+  margin: 24px auto 0;
 }
 
 .df-actions--stack {
@@ -166,8 +186,6 @@
 }
 
 .df-button,
-.df-intention,
-.df-hold,
 .df-settings-link {
   appearance: none;
   border: 0;
@@ -211,25 +229,6 @@
   text-underline-offset: 3px;
 }
 
-.df-intentions {
-  display: grid;
-  gap: 8px;
-  margin-top: 26px;
-}
-
-.df-intention {
-  display: flex;
-  min-height: 54px;
-  align-items: center;
-  justify-content: space-between;
-  padding: 14px 16px;
-  border: 1px solid var(--df-line);
-  color: var(--df-ink);
-  background: rgba(255, 255, 255, 0.38);
-  text-align: left;
-}
-
-.df-intention:active,
 .df-button:active {
   transform: translateY(1px);
 }
@@ -280,10 +279,10 @@
   min-width: 142px;
   align-items: center;
   padding: 9px 12px;
-  border: 1px solid rgba(243, 239, 228, 0.5);
+  border: 1px solid rgba(240, 241, 237, 0.28);
   border-radius: 2px;
-  color: var(--df-paper);
-  background: rgba(23, 32, 24, 0.94);
+  color: #f0f1ed;
+  background: rgba(21, 23, 22, 0.96);
   box-shadow: 0 8px 30px rgba(0, 0, 0, 0.28);
   font: inherit;
   text-align: left;
@@ -296,7 +295,7 @@
   height: 9px;
   border-radius: 50%;
   background: var(--df-accent);
-  box-shadow: 0 0 0 4px rgba(204, 255, 0, 0.14);
+  box-shadow: 0 0 0 4px rgba(146, 154, 148, 0.14);
 }
 
 .df-usage-timer__copy {
@@ -314,7 +313,7 @@
 
 .df-usage-timer small {
   margin-top: 3px;
-  color: rgba(243, 239, 228, 0.68);
+  color: rgba(240, 241, 237, 0.68);
   font-size: 9px;
   font-weight: 700;
   letter-spacing: 0.06em;
@@ -322,48 +321,18 @@
 }
 
 .df-usage-timer[data-urgent="true"] {
-  border-color: var(--df-ink);
-  color: var(--df-ink);
-  background: var(--df-accent);
+  border-color: #929a94;
+  color: #f0f1ed;
+  background: #252927;
 }
 
 .df-usage-timer[data-urgent="true"] small {
-  color: rgba(23, 32, 24, 0.68);
+  color: rgba(240, 241, 237, 0.68);
 }
 
 .df-usage-timer[data-urgent="true"] .df-usage-timer__pulse {
-  background: var(--df-ink);
+  background: #f0f1ed;
   animation: df-timer-pulse 1s ease-in-out infinite;
-}
-
-.df-hold {
-  position: relative;
-  isolation: isolate;
-  overflow: hidden;
-  width: 100%;
-  min-height: 62px;
-  margin-top: 12px;
-  border: 1px solid var(--df-ink);
-  color: var(--df-ink);
-  background: transparent;
-  font-weight: 800;
-}
-
-.df-hold > span:first-child {
-  position: relative;
-  z-index: 1;
-}
-
-.df-hold__progress {
-  position: absolute;
-  z-index: 0;
-  inset: 0 auto 0 0;
-  width: var(--df-hold-progress);
-  background: var(--df-accent);
-}
-
-.df-hold:disabled {
-  opacity: 0.5;
 }
 
 .df-wait {
@@ -393,12 +362,12 @@
 
 @media (min-width: 680px) {
   .df-backdrop {
-    align-items: center;
-    padding: 28px;
+    align-items: stretch;
+    padding: 0;
   }
 
   .df-card {
-    padding: 42px 40px 28px;
+    padding: 48px 40px;
   }
 }
 

--- a/docs/REDDIT_ADAPTER_NOTES.md
+++ b/docs/REDDIT_ADAPTER_NOTES.md
@@ -1,0 +1,115 @@
+# Reddit adapter notes
+
+This document records observations from manual and remote inspection of the
+authenticated Reddit web feed. It is intended to make future selector and
+finite-feed work reproducible.
+
+## Verified environment
+
+- Date: 2026-08-02
+- Browser: Firefox 153.0.1 on Windows
+- Page: authenticated `https://www.reddit.com/` desktop feed with Spanish Reddit UI
+- Extension: Firefox MV2 production build loaded temporarily through `web-ext`
+- Profile: temporary copy of the maintainer's normal Firefox profile
+- Observed viewport height: 860 CSS pixels
+
+Android and Chromium were not manually verified during this inspection.
+
+## Current post structure
+
+The inspected desktop feed used `shreddit-post` as its top-level post element.
+Each post exposed a stable Reddit fullname through its `id`, for example
+`t3_1vcwk92`, and was wrapped by an `article.w-full.m-0` element.
+
+Observed selector counts before limiting:
+
+| Selector | Matches |
+| --- | ---: |
+| `shreddit-post` | 28 |
+| `[data-testid="post-unit"]` | 0 |
+| `[data-testid="post-container"]` | 0 |
+| `article[data-testid="post"]` | 0 |
+
+The fallback selectors remain useful for other Reddit layouts, but
+`shreddit-post[id]` is the verified contract for this one. Selector confidence
+must remain narrow; do not hide a broad feed ancestor when this contract is
+missing.
+
+## Virtualization discovery
+
+Reddit recycles the feed DOM during long scrolls. In one inspection the page
+was at approximately `scrollY = 98,759` while only 28 `shreddit-post` elements
+remained in the document. Old posts had been removed and replaced with newer
+ones while Reddit preserved virtual scroll height.
+
+Limiting `regularPosts.slice(0, allowance)` is therefore incorrect. It limits
+only the current DOM window and effectively grants a fresh allowance whenever
+Reddit removes earlier nodes.
+
+The limiter now keeps stable post identities in memory for the active page
+session:
+
+- Reddit uses the `t3_*` element id.
+- Already revealed identities remain allowed if Reddit recreates their nodes.
+- New identities are hidden once the reserved batch is full.
+- Post identities are never persisted or transmitted.
+- Elements without a stable platform key receive an element-scoped fallback
+  key, which fails closed when virtualization replaces them.
+
+## Inline batch boundary
+
+The batch boundary is not a modal. The extension inserts an isolated inline
+control immediately after the last revealed post, or immediately before the
+first blocked post when Reddit has already appended more content.
+
+Reddit may remove extension-owned nodes while reconciling its feed. The
+mutation observer therefore restores the control beside the current boundary.
+The control also clamps the document scroll position while the batch is
+closed. This is necessary because Reddit can preserve virtual height or append
+loader space even when every new post element is hidden.
+
+Completing the configured wait and press-and-hold action reserves and reveals
+only the next configured batch. The scroll clamp is removed until the next
+boundary is reached.
+
+## Real-session results
+
+With an initial allowance of 20 posts:
+
+1. Reddit initially exposed 28 posts.
+2. The limiter left 20 visible and hid 8.
+3. A forced long scroll caused Reddit to recycle old nodes and expose 34
+   current post elements.
+4. Only one previously revealed element remained in the virtualized DOM; all
+   33 new elements were hidden.
+5. The inline gate was held at approximately 16 CSS pixels from the top of the
+   viewport, preventing further scrolling until another batch was requested.
+
+These numbers describe the current DOM, not the total number of posts Reddit
+had fetched during the entire test.
+
+## Known limitations
+
+- This is finite-feed pagination at the presentation layer. Reddit may still
+  prefetch hidden posts or loader data in the background.
+- The extension does not intercept Reddit requests, use Reddit APIs or request
+  additional network permissions.
+- Reddit selectors and wrappers are volatile and require signed-in desktop and
+  mobile smoke tests after platform changes.
+- A browser-level test should eventually simulate DOM recycling and verify
+  that stable post identities cannot reopen a consumed batch.
+
+## Manual verification checklist
+
+1. Open the authenticated Reddit home feed in a fresh tab.
+2. Start a Dopamine Fast session and confirm the configured first batch size.
+3. Scroll through the full batch and confirm that no full-screen batch dialog
+   appears.
+4. Confirm the inline control is visible and the document cannot scroll past
+   it.
+5. Complete the wait and hold action and confirm exactly the configured extra
+   batch becomes visible.
+6. Continue far enough to trigger Reddit virtualization and confirm the next
+   inline boundary still appears.
+7. Navigate to a post detail, messages and settings to confirm those routes
+   remain outside the limiter.

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,0 +1,45 @@
+import {
+  addUsageSecondsFromStorage,
+  reserveAllowanceFromStorage,
+  resetDailyStateFromStorage,
+} from "../lib/storage";
+import { isRuntimeMessage } from "../lib/runtime-messages";
+import { SerialQueue } from "../lib/serial-queue";
+
+export default defineBackground(() => {
+  const mutations = new SerialQueue();
+
+  browser.runtime.onMessage.addListener((message: unknown, sender) => {
+    if (!isRuntimeMessage(message)) return undefined;
+
+    switch (message.type) {
+      case "dopamine-fast:reserve-allowance":
+        return mutations.run(async () => ({
+          granted: await reserveAllowanceFromStorage(
+            message.platform,
+            message.requested,
+            message.isUnlock,
+          ),
+        }));
+      case "dopamine-fast:add-usage-seconds":
+        return mutations.run(async () => ({
+          remainingSeconds: await addUsageSecondsFromStorage(
+            message.platform,
+            message.elapsedSeconds,
+          ),
+        }));
+      case "dopamine-fast:reset-daily-state":
+        return mutations.run(async () => {
+          await resetDailyStateFromStorage();
+          return { ok: true };
+        });
+      case "dopamine-fast:open-options":
+        return browser.runtime.openOptionsPage().then(() => ({ ok: true }));
+      case "dopamine-fast:leave-feed":
+        if (sender.tab?.id === undefined) return { ok: false };
+        return browser.tabs
+          .update(sender.tab.id, { url: "about:blank" })
+          .then(() => ({ ok: true }));
+    }
+  });
+});

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -7,6 +7,7 @@ import {
   getDailyUsageState,
   getSettings,
   reserveAllowance,
+  dailyUsageStateItem,
   settingsItem,
 } from "../lib/storage";
 import { UsageSession } from "../lib/usage-session";
@@ -111,7 +112,6 @@ export default defineContentScript({
       limiter = new FeedLimiter(
         adapter,
         settings,
-        intervention,
         initialAllowance,
       );
       limiter.start();
@@ -135,8 +135,8 @@ export default defineContentScript({
             ) {
               return;
             }
+            if (extensionSeconds <= 0) return;
             session.extend(extensionSeconds);
-            limiter?.restoreEndOfBatch();
           })();
         },
         onHardLimitReached() {
@@ -168,9 +168,32 @@ export default defineContentScript({
       void activate();
     });
 
+    const unwatchUsage = dailyUsageStateItem.watch(() => {
+      const session = usageSession;
+      const watchedActivation = activationId;
+      if (!session) return;
+
+      void (async () => {
+        const [settings, usageState] = await Promise.all([
+          getSettings(),
+          getDailyUsageState(),
+        ]);
+        if (
+          watchedActivation !== activationId ||
+          session !== usageSession
+        ) {
+          return;
+        }
+        session.syncAvailableSeconds(
+          availableUsageSeconds(settings, usageState, adapter.id),
+        );
+      })();
+    });
+
     ctx.onInvalidated(() => {
       window.clearInterval(navigationTimer);
       unwatchSettings();
+      unwatchUsage();
       limiter?.destroy();
       void usageSession?.destroy();
       shadowUi.remove();

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="manifest.open_in_tab" content="true" />
     <title>Dopamine Fast — Settings</title>
     <script type="module" src="./main.ts"></script>
   </head>

--- a/lib/batch-gate-ui.ts
+++ b/lib/batch-gate-ui.ts
@@ -1,0 +1,256 @@
+export interface BatchGateOptions {
+  unlockSize: number;
+  remainingToday: number;
+  canUnlock: boolean;
+  unlockDelaySeconds: number;
+  holdSeconds: number;
+  onUnlock(): Promise<number>;
+}
+
+export class BatchGateUi {
+  private readonly host = document.createElement("div");
+  private readonly shadow = this.host.attachShadow({ mode: "closed" });
+  private boundary?: HTMLElement;
+  private placement: "before" | "after" = "after";
+  private renderKey = "";
+  private countdownTimer?: number;
+  private animationFrame?: number;
+  private scrollGuardActive = false;
+
+  constructor() {
+    this.host.dataset.dopamineFastBatchGate = "true";
+  }
+
+  showAfter(boundary: HTMLElement, options: BatchGateOptions): void {
+    this.showAt(boundary, "after", options);
+  }
+
+  showBefore(boundary: HTMLElement, options: BatchGateOptions): void {
+    this.showAt(boundary, "before", options);
+  }
+
+  private showAt(
+    boundary: HTMLElement,
+    placement: "before" | "after",
+    options: BatchGateOptions,
+  ): void {
+    const renderKey = [
+      options.unlockSize,
+      options.remainingToday,
+      options.canUnlock,
+      options.unlockDelaySeconds,
+      options.holdSeconds,
+    ].join(":");
+
+    if (
+      this.boundary !== boundary ||
+      this.placement !== placement ||
+      this.renderKey !== renderKey
+    ) {
+      this.boundary = boundary;
+      this.placement = placement;
+      this.renderKey = renderKey;
+      this.render(options);
+    }
+
+    this.ensurePlacement(boundary, placement);
+    this.startScrollGuard();
+  }
+
+  isFor(boundary: HTMLElement, placement: "before" | "after"): boolean {
+    return (
+      this.boundary === boundary &&
+      this.placement === placement &&
+      this.renderKey.length > 0
+    );
+  }
+
+  ensurePlacement(
+    boundary: HTMLElement,
+    placement: "before" | "after",
+  ): void {
+    if (!this.isFor(boundary, placement)) return;
+    const correctlyPlaced =
+      placement === "after"
+        ? boundary.nextElementSibling === this.host
+        : boundary.previousElementSibling === this.host;
+    if (!correctlyPlaced) {
+      boundary.insertAdjacentElement(
+        placement === "after" ? "afterend" : "beforebegin",
+        this.host,
+      );
+    }
+  }
+
+  hide(): void {
+    this.clearTimers();
+    this.stopScrollGuard();
+    this.host.remove();
+    this.boundary = undefined;
+    this.placement = "after";
+    this.renderKey = "";
+  }
+
+  destroy(): void {
+    this.hide();
+  }
+
+  private render(options: BatchGateOptions): void {
+    this.clearTimers();
+    this.shadow.replaceChildren();
+
+    const style = document.createElement("style");
+    style.textContent = `
+      :host { display: block; width: 100%; }
+      .gate { box-sizing: border-box; width: min(100%, 680px); margin: 20px auto; padding: 24px; border: 1px solid rgba(128, 128, 128, .35); border-radius: 12px; background: #151716; color: #f0f1ed; font: 14px/1.45 system-ui, sans-serif; text-align: center; }
+      .label { margin: 0 0 6px; color: #a5aaa6; font-size: 11px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+      .copy { margin: 0 0 16px; font-size: 15px; }
+      button { position: relative; overflow: hidden; width: 100%; min-height: 48px; padding: 12px 16px; border: 1px solid #929a94; border-radius: 8px; background: transparent; color: #f0f1ed; font: inherit; font-weight: 800; cursor: pointer; touch-action: none; }
+      button::before { position: absolute; inset: 0; width: var(--progress, 0%); background: rgba(146, 154, 148, .25); content: ""; pointer-events: none; }
+      button span { position: relative; }
+      button:disabled { cursor: default; opacity: .55; }
+    `;
+    const gate = document.createElement("section");
+    gate.className = "gate";
+    gate.setAttribute("aria-label", "End of current post batch");
+
+    const label = document.createElement("p");
+    label.className = "label";
+    label.textContent = "End of this batch";
+    const copy = document.createElement("p");
+    copy.className = "copy";
+
+    gate.append(label, copy);
+
+    if (!options.canUnlock) {
+      copy.textContent = "You have reached today's post limit.";
+      this.shadow.append(style, gate);
+      return;
+    }
+
+    copy.textContent = `${options.remainingToday} posts remain in today's limit.`;
+    const button = document.createElement("button");
+    button.type = "button";
+    button.disabled = options.unlockDelaySeconds > 0;
+    const buttonLabel = document.createElement("span");
+    button.append(buttonLabel);
+    gate.append(button);
+    this.shadow.append(style, gate);
+
+    let remaining = options.unlockDelaySeconds;
+    const readyLabel = `Hold to load ${options.unlockSize} more posts`;
+    const updateCountdown = () => {
+      buttonLabel.textContent =
+        remaining > 0
+          ? `Load ${options.unlockSize} more posts in ${remaining}s`
+          : readyLabel;
+    };
+    updateCountdown();
+
+    if (remaining > 0) {
+      this.countdownTimer = window.setInterval(() => {
+        remaining -= 1;
+        updateCountdown();
+        if (remaining <= 0) {
+          if (this.countdownTimer) window.clearInterval(this.countdownTimer);
+          this.countdownTimer = undefined;
+          button.disabled = false;
+        }
+      }, 1000);
+    }
+
+    let holdStarted = 0;
+    let completed = false;
+    const cancelHold = () => {
+      if (completed) return;
+      holdStarted = 0;
+      if (this.animationFrame) window.cancelAnimationFrame(this.animationFrame);
+      this.animationFrame = undefined;
+      button.style.setProperty("--progress", "0%");
+    };
+    const updateHold = (now: number) => {
+      const progress = Math.min(
+        1,
+        (now - holdStarted) / (options.holdSeconds * 1000),
+      );
+      button.style.setProperty("--progress", `${Math.round(progress * 100)}%`);
+      if (progress < 1) {
+        this.animationFrame = window.requestAnimationFrame(updateHold);
+        return;
+      }
+
+      completed = true;
+      button.disabled = true;
+      buttonLabel.textContent = "Loading posts…";
+      void options
+        .onUnlock()
+        .then((granted) => {
+          if (granted <= 0) {
+            this.render({ ...options, canUnlock: false, remainingToday: 0 });
+          }
+        })
+        .catch(() => {
+          completed = false;
+          holdStarted = 0;
+          button.disabled = false;
+          buttonLabel.textContent = readyLabel;
+          button.style.setProperty("--progress", "0%");
+        });
+    };
+    const startHold = () => {
+      if (button.disabled || holdStarted > 0) return;
+      holdStarted = performance.now();
+      this.animationFrame = window.requestAnimationFrame(updateHold);
+    };
+
+    button.addEventListener("pointerdown", (event) => {
+      event.preventDefault();
+      if (button.disabled) return;
+      button.setPointerCapture(event.pointerId);
+      startHold();
+    });
+    button.addEventListener("pointerup", cancelHold);
+    button.addEventListener("pointercancel", cancelHold);
+    button.addEventListener("lostpointercapture", cancelHold);
+    button.addEventListener("keydown", (event) => {
+      if (event.key !== " " && event.key !== "Enter") return;
+      event.preventDefault();
+      startHold();
+    });
+    button.addEventListener("keyup", (event) => {
+      if (event.key !== " " && event.key !== "Enter") return;
+      event.preventDefault();
+      cancelHold();
+    });
+  }
+
+  private clearTimers(): void {
+    if (this.countdownTimer) window.clearInterval(this.countdownTimer);
+    if (this.animationFrame) window.cancelAnimationFrame(this.animationFrame);
+    this.countdownTimer = undefined;
+    this.animationFrame = undefined;
+  }
+
+  private startScrollGuard(): void {
+    if (this.scrollGuardActive) return;
+    this.scrollGuardActive = true;
+    window.addEventListener("scroll", this.keepGateInView, { passive: true });
+    this.keepGateInView();
+  }
+
+  private stopScrollGuard(): void {
+    if (!this.scrollGuardActive) return;
+    this.scrollGuardActive = false;
+    window.removeEventListener("scroll", this.keepGateInView);
+  }
+
+  private readonly keepGateInView = (): void => {
+    if (!this.scrollGuardActive || !this.host.isConnected) return;
+    const top = this.host.getBoundingClientRect().top;
+    if (top >= 16) return;
+    window.scrollTo({
+      top: Math.max(0, window.scrollY + top - 16),
+      behavior: "auto",
+    });
+  };
+}

--- a/lib/feed-limiter.ts
+++ b/lib/feed-limiter.ts
@@ -3,9 +3,9 @@ import {
   hasSuggestedMarker,
   type PlatformAdapter,
 } from "./platforms";
+import { BatchGateUi } from "./batch-gate-ui";
 import { dailyStateItem, reserveAllowance } from "./storage";
 import { availableAllowance, normalizeDailyState, type Settings } from "./models";
-import type { InterventionUi } from "./intervention-ui";
 
 interface OriginalDisplay {
   value: string;
@@ -15,28 +15,21 @@ interface OriginalDisplay {
 export class FeedLimiter {
   private allowance: number;
   private readonly hidden = new Map<HTMLElement, OriginalDisplay>();
-  private readonly boundaryObserver: IntersectionObserver;
+  private readonly revealedPostKeys = new Set<string>();
+  private readonly fallbackPostKeys = new WeakMap<HTMLElement, string>();
+  private readonly gate = new BatchGateUi();
   private readonly mutationObserver: MutationObserver;
-  private observedBoundary?: HTMLElement;
   private processingTimer?: number;
-  private endVisible = false;
+  private gateRequestId = 0;
+  private nextFallbackPostKey = 1;
   private destroyed = false;
 
   constructor(
     private readonly adapter: PlatformAdapter,
     private readonly settings: Settings,
-    private readonly ui: InterventionUi,
     initialAllowance: number,
   ) {
     this.allowance = initialAllowance;
-    this.boundaryObserver = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          void this.presentEndOfBatch();
-        }
-      },
-      { rootMargin: "0px 0px 180px 0px", threshold: 0.15 },
-    );
     this.mutationObserver = new MutationObserver(() => this.scheduleProcess());
   }
 
@@ -51,20 +44,13 @@ export class FeedLimiter {
   destroy(): void {
     this.destroyed = true;
     this.mutationObserver.disconnect();
-    this.boundaryObserver.disconnect();
     if (this.processingTimer) window.clearTimeout(this.processingTimer);
     this.hidden.forEach((display, element) => {
       element.style.setProperty("display", display.value, display.priority);
       delete element.dataset.dopamineFastHidden;
     });
     this.hidden.clear();
-    this.ui.hide();
-  }
-
-  restoreEndOfBatch(): void {
-    if (!this.endVisible || this.destroyed) return;
-    this.endVisible = false;
-    void this.presentEndOfBatch();
+    this.gate.destroy();
   }
 
   private scheduleProcess(): void {
@@ -102,35 +88,76 @@ export class FeedLimiter {
       return !suggested;
     });
 
-    regularPosts.forEach((post, index) => {
-      if (index < this.allowance) this.showElement(post);
-      else this.hideElement(post);
+    let firstBlockedPost: HTMLElement | undefined;
+    let lastVisiblePost: HTMLElement | undefined;
+    regularPosts.forEach((post) => {
+      const postKey = this.getPostKey(post);
+      if (
+        this.revealedPostKeys.has(postKey) ||
+        this.revealedPostKeys.size < this.allowance
+      ) {
+        this.revealedPostKeys.add(postKey);
+        this.showElement(post);
+        lastVisiblePost = post;
+      } else {
+        firstBlockedPost ??= post;
+        this.hideElement(post);
+      }
     });
 
-    const boundary = regularPosts[this.allowance - 1];
-    if (boundary && boundary !== this.observedBoundary) {
-      if (this.observedBoundary) {
-        this.boundaryObserver.unobserve(this.observedBoundary);
-      }
-      this.observedBoundary = boundary;
-      this.boundaryObserver.observe(boundary);
+    if (this.revealedPostKeys.size < this.allowance) {
+      this.renderGate(undefined, "after");
+    } else if (firstBlockedPost) {
+      this.renderGate(firstBlockedPost, "before");
+    } else {
+      this.renderGate(lastVisiblePost, "after");
     }
-
-    if (this.allowance === 0) void this.presentEndOfBatch();
   }
 
-  private async presentEndOfBatch(): Promise<void> {
-    if (this.endVisible || this.destroyed) return;
-    this.endVisible = true;
+  private getPostKey(post: HTMLElement): string {
+    const platformKey = this.adapter.getPostKey(post);
+    if (platformKey) return `${this.adapter.id}:${platformKey}`;
 
+    const existing = this.fallbackPostKeys.get(post);
+    if (existing) return existing;
+    const fallback = `${this.adapter.id}:element:${this.nextFallbackPostKey++}`;
+    this.fallbackPostKeys.set(post, fallback);
+    return fallback;
+  }
+
+  private renderGate(
+    boundary: HTMLElement | undefined,
+    placement: "before" | "after",
+  ): void {
+    if (!boundary) {
+      this.gateRequestId += 1;
+      this.gate.hide();
+      return;
+    }
+    if (this.gate.isFor(boundary, placement)) {
+      this.gate.ensurePlacement(boundary, placement);
+      return;
+    }
+    const requestId = ++this.gateRequestId;
+    void this.loadGate(boundary, placement, requestId);
+  }
+
+  private async loadGate(
+    boundary: HTMLElement,
+    placement: "before" | "after",
+    requestId: number,
+  ): Promise<void> {
     const state = normalizeDailyState(await dailyStateItem.getValue());
+    if (this.destroyed || requestId !== this.gateRequestId) return;
     const remainingToday = availableAllowance(this.settings, state);
     const balancedUnlockAvailable =
       this.settings.mode !== "balanced" || state.unlocks < 2;
     const canUnlock = remainingToday > 0 && balancedUnlockAvailable;
 
-    this.ui.showEndOfBatch({
-      platformLabel: this.adapter.label,
+    const showGate = placement === "after"
+      ? this.gate.showAfter.bind(this.gate)
+      : this.gate.showBefore.bind(this.gate);
+    showGate(boundary, {
       unlockSize: Math.min(this.settings.unlockBatchSize, remainingToday),
       remainingToday,
       canUnlock,
@@ -144,7 +171,7 @@ export class FeedLimiter {
         );
         if (granted > 0) {
           this.allowance += granted;
-          this.endVisible = false;
+          this.gate.hide();
           this.process();
         }
         return granted;

--- a/lib/intervention-ui.ts
+++ b/lib/intervention-ui.ts
@@ -1,12 +1,5 @@
-export interface EndOfBatchOptions {
-  platformLabel: string;
-  unlockSize: number;
-  remainingToday: number;
-  canUnlock: boolean;
-  unlockDelaySeconds: number;
-  holdSeconds: number;
-  onUnlock(): Promise<number>;
-}
+import type { RuntimeMessage } from "./runtime-messages";
+import { sessionMinuteChoices } from "./session-time";
 
 export interface OpeningOptions {
   platformLabel: string;
@@ -27,12 +20,7 @@ export interface SessionEndedOptions {
   availableSeconds: number;
 }
 
-const intentions = [
-  ["specific", "I'm looking for something specific"],
-  ["reply", "I want to reply or interact"],
-  ["deliberate", "I want to keep reading"],
-  ["automatic", "I'm scrolling on autopilot"],
-] as const;
+const SESSION_REPLAN_DELAY_SECONDS = 10;
 
 export class InterventionUi {
   private readonly root: HTMLElement;
@@ -90,19 +78,14 @@ export class InterventionUi {
           <p class="df-copy">
             Choose a defined session now. The timer will remain visible as you browse.
           </p>
-          <label class="df-time-choice">
+          <div class="df-time-choice df-time-stepper">
             <span>This session</span>
-            <output for="df-session-minutes">${defaultSessionLabel}</output>
-            <input
-              id="df-session-minutes"
-              type="range"
-              min="1"
-              max="${maximumMinutes}"
-              value="${defaultMinutes}"
-              step="1"
-              ${options.availableSeconds < 60 ? "disabled" : ""}
-            />
-          </label>
+            <output aria-live="polite">${defaultSessionLabel}</output>
+            <div class="df-time-buttons" role="group" aria-label="Adjust session length">
+              <button type="button" data-action="time-less" aria-label="Choose a shorter session">Less</button>
+              <button type="button" data-action="time-more" aria-label="Add more session time">Add time</button>
+            </div>
+          </div>
           <p class="df-hard-limit-note">
             You have <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong>
             left in today's limit for this network.
@@ -123,10 +106,6 @@ export class InterventionUi {
     `;
 
     const countdown = this.overlay.querySelector<HTMLElement>(".df-countdown");
-    const sessionInput =
-      this.requiredElement<HTMLInputElement>("#df-session-minutes");
-    const sessionOutput =
-      this.requiredElement<HTMLOutputElement>(".df-time-choice output");
     const continueButton =
       this.requiredElement<HTMLButtonElement>('[data-action="continue"]');
     const leaveButton =
@@ -134,19 +113,19 @@ export class InterventionUi {
     const settingsButton =
       this.requiredElement<HTMLButtonElement>('[data-action="settings"]');
 
-    leaveButton.addEventListener("click", () => history.back());
-    settingsButton.addEventListener("click", () =>
-      browser.runtime.openOptionsPage(),
+    leaveButton.addEventListener("click", () => this.leaveFeed());
+    settingsButton.addEventListener("click", () => this.openOptions());
+    const timeStepper = this.bindTimeStepper(
+      this.overlay,
+      maximumMinutes,
+      defaultMinutes,
+      options.availableSeconds,
+      (label) => {
+        if (!continueButton.disabled) {
+          continueButton.textContent = `Start ${label} session`;
+        }
+      },
     );
-
-    sessionInput.addEventListener("input", () => {
-      const label =
-        options.availableSeconds < 60 ? "<1 min" : `${sessionInput.value} min`;
-      sessionOutput.value = label;
-      if (!continueButton.disabled) {
-        continueButton.textContent = `Start ${label} session`;
-      }
-    });
 
     return new Promise<number>((resolve) => {
       let remaining = options.delaySeconds;
@@ -164,11 +143,7 @@ export class InterventionUi {
           continueButton.textContent =
             remaining > 0
               ? `Continue in ${remaining}s`
-              : `Start ${
-                  options.availableSeconds < 60
-                    ? "<1 min"
-                    : `${sessionInput.value} min`
-                } session`;
+              : `Start ${timeStepper.getLabel()} session`;
 
           if (remaining <= 0) {
             if (interval !== undefined) window.clearInterval(interval);
@@ -180,7 +155,7 @@ export class InterventionUi {
       continueButton.addEventListener("click", () => {
         if (interval !== undefined) window.clearInterval(interval);
         const selectedSeconds = Math.min(
-          Number(sessionInput.value) * 60,
+          timeStepper.getMinutes() * 60,
           options.availableSeconds,
         );
         this.cancelPendingInteraction = undefined;
@@ -190,43 +165,81 @@ export class InterventionUi {
     });
   }
 
-  showEndOfBatch(options: EndOfBatchOptions): void {
+  showSessionEnded(options: SessionEndedOptions): Promise<number> {
     this.lockPage();
     this.overlay.innerHTML = `
-      <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-end-title">
+      <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-session-end-title">
         <article class="df-card">
           <div class="df-rule"></div>
-          <p class="df-kicker">End of batch</p>
-          <h1 id="df-end-title">That's enough for now.</h1>
+          <p class="df-kicker">Planned time complete</p>
+          <h1 id="df-session-end-title">Your session has ended.</h1>
           <p class="df-copy">
-            ${options.remainingToday > 0
-              ? `You have ${options.remainingToday} posts left in today's limit.`
-              : "You've reached today's limit."}
+            You chose to stop here. Leave now, or pause before deliberately planning more time.
           </p>
-          <div class="df-actions df-actions--stack">
+          <p class="df-hard-limit-note">
+            Your daily ceiling cannot be extended:
+            <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong> remaining.
+          </p>
+          <div class="df-actions">
             <button class="df-button df-button--primary" data-action="leave">Leave ${options.platformLabel}</button>
-            ${
-              options.canUnlock
-                ? `<button class="df-button df-button--quiet" data-action="unlock">Unlock ${options.unlockSize} more</button>`
-                : ""
-            }
+            <button class="df-button df-button--quiet" data-action="plan" disabled>
+              Plan another block in ${SESSION_REPLAN_DELAY_SECONDS}s
+            </button>
           </div>
-          <button class="df-settings-link" data-action="settings">Change limits</button>
+          <p class="df-wait" aria-live="polite">Take a moment before deciding.</p>
+          <button class="df-settings-link" data-action="settings">Change the default</button>
         </article>
       </section>
     `;
 
-    this.requiredElement<HTMLButtonElement>('[data-action="leave"]')
-      .addEventListener("click", () => history.back());
+    const leaveButton =
+      this.requiredElement<HTMLButtonElement>('[data-action="leave"]');
+    const planButton =
+      this.requiredElement<HTMLButtonElement>('[data-action="plan"]');
+    const waitLabel = this.requiredElement<HTMLElement>(".df-wait");
     this.requiredElement<HTMLButtonElement>('[data-action="settings"]')
-      .addEventListener("click", () => browser.runtime.openOptionsPage());
-    this.overlay
-      .querySelector<HTMLButtonElement>('[data-action="unlock"]')
-      ?.addEventListener("click", () => this.showIntentionStep(options));
+      .addEventListener("click", () => this.openOptions());
+
+    return new Promise<number>((resolve) => {
+      let remaining = SESSION_REPLAN_DELAY_SECONDS;
+      const interval = window.setInterval(() => {
+        remaining -= 1;
+        planButton.textContent =
+          remaining > 0
+            ? `Plan another block in ${remaining}s`
+            : "Plan another block";
+        if (remaining <= 0) {
+          window.clearInterval(interval);
+          planButton.disabled = false;
+          waitLabel.textContent = "You can now plan another block.";
+        }
+      }, 1000);
+
+      const finishWithoutExtension = () => {
+        window.clearInterval(interval);
+        this.cancelPendingInteraction = undefined;
+        resolve(0);
+      };
+      this.cancelPendingInteraction = () => {
+        window.clearInterval(interval);
+        resolve(0);
+      };
+      leaveButton.addEventListener("click", () => {
+        finishWithoutExtension();
+        this.leaveFeed();
+      });
+      planButton.addEventListener("click", () => {
+        if (planButton.disabled) return;
+        window.clearInterval(interval);
+        this.showSessionPlanning(options, resolve);
+      });
+    });
   }
 
-  showSessionEnded(options: SessionEndedOptions): Promise<number> {
-    this.lockPage();
+  private showSessionPlanning(
+    options: SessionEndedOptions,
+    resolve: (seconds: number) => void,
+  ): void {
     const maximumMinutes = Math.max(
       1,
       Math.min(60, Math.ceil(options.availableSeconds / 60)),
@@ -237,65 +250,54 @@ export class InterventionUi {
     );
     const defaultSessionLabel =
       options.availableSeconds < 60 ? "<1 min" : `${defaultMinutes} min`;
-    this.overlay.innerHTML = `
-      <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-session-end-title">
-        <article class="df-card">
-          <div class="df-rule"></div>
-          <p class="df-kicker">Planned time complete</p>
-          <h1 id="df-session-end-title">Your session has ended.</h1>
-          <p class="df-copy">
-            You chose to stop here. If you still have a specific reason, you can plan another block.
-          </p>
-          <label class="df-time-choice">
-            <span>New block</span>
-            <output for="df-extra-minutes">${defaultSessionLabel}</output>
-            <input
-              id="df-extra-minutes"
-              type="range"
-              min="1"
-              max="${maximumMinutes}"
-              value="${defaultMinutes}"
-              step="1"
-              ${options.availableSeconds < 60 ? "disabled" : ""}
-            />
-          </label>
-          <p class="df-hard-limit-note">
-            Your daily ceiling cannot be extended:
-            <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong> remaining.
-          </p>
-          <div class="df-actions">
-            <button class="df-button df-button--primary" data-action="leave">Leave ${options.platformLabel}</button>
-            <button class="df-button df-button--quiet" data-action="extend">Plan another block</button>
-          </div>
-          <button class="df-settings-link" data-action="settings">Change the default</button>
-        </article>
-      </section>
+    const card = this.requiredElement<HTMLElement>(".df-card");
+    card.innerHTML = `
+      <p class="df-kicker">Plan another block</p>
+      <h1>How much longer?</h1>
+      <p class="df-copy">Choose a defined block within today's remaining ceiling.</p>
+      <div class="df-time-choice df-time-stepper">
+        <span>New block</span>
+        <output aria-live="polite">${defaultSessionLabel}</output>
+        <div class="df-time-buttons" role="group" aria-label="Adjust new block length">
+          <button type="button" data-action="time-less" aria-label="Choose a shorter block">Less</button>
+          <button type="button" data-action="time-more" aria-label="Add more time to the block">Add time</button>
+        </div>
+      </div>
+      <div class="df-actions">
+        <button class="df-button df-button--quiet" data-action="leave">Leave ${options.platformLabel}</button>
+        <button class="df-button df-button--primary" data-action="extend">Start ${defaultSessionLabel} block</button>
+      </div>
+      <button class="df-settings-link" data-action="settings">Change the default</button>
     `;
 
-    const input = this.requiredElement<HTMLInputElement>("#df-extra-minutes");
-    const output =
-      this.requiredElement<HTMLOutputElement>(".df-time-choice output");
-    input.addEventListener("input", () => {
-      output.value =
-        options.availableSeconds < 60 ? "<1 min" : `${input.value} min`;
-    });
+    const extendButton =
+      this.requiredElement<HTMLButtonElement>('[data-action="extend"]');
+    const timeStepper = this.bindTimeStepper(
+      card,
+      maximumMinutes,
+      defaultMinutes,
+      options.availableSeconds,
+      (label) => {
+        extendButton.textContent = `Start ${label} block`;
+      },
+    );
     this.requiredElement<HTMLButtonElement>('[data-action="leave"]')
-      .addEventListener("click", () => history.back());
+      .addEventListener("click", () => {
+        this.cancelPendingInteraction = undefined;
+        resolve(0);
+        this.leaveFeed();
+      });
     this.requiredElement<HTMLButtonElement>('[data-action="settings"]')
-      .addEventListener("click", () => browser.runtime.openOptionsPage());
-
-    return new Promise<number>((resolve) => {
-      this.cancelPendingInteraction = () => resolve(0);
-      this.requiredElement<HTMLButtonElement>('[data-action="extend"]')
-        .addEventListener("click", () => {
-          const selectedSeconds = Math.min(
-            Number(input.value) * 60,
-            options.availableSeconds,
-          );
-          this.cancelPendingInteraction = undefined;
-          this.hide();
-          resolve(selectedSeconds);
-        });
+      .addEventListener("click", () => this.openOptions());
+    this.cancelPendingInteraction = () => resolve(0);
+    extendButton.addEventListener("click", () => {
+      const selectedSeconds = Math.min(
+        timeStepper.getMinutes() * 60,
+        options.availableSeconds,
+      );
+      this.cancelPendingInteraction = undefined;
+      this.hide();
+      resolve(selectedSeconds);
     });
   }
 
@@ -322,9 +324,9 @@ export class InterventionUi {
     `;
 
     this.requiredElement<HTMLButtonElement>('[data-action="leave"]')
-      .addEventListener("click", () => history.back());
+      .addEventListener("click", () => this.leaveFeed());
     this.requiredElement<HTMLButtonElement>('[data-action="settings"]')
-      .addEventListener("click", () => browser.runtime.openOptionsPage());
+      .addEventListener("click", () => this.openOptions());
   }
 
   showUsageTimer(options: UsageTimerOptions): void {
@@ -340,7 +342,7 @@ export class InterventionUi {
       `;
       this.timer
         .querySelector<HTMLButtonElement>(".df-usage-timer")
-        ?.addEventListener("click", () => browser.runtime.openOptionsPage());
+        ?.addEventListener("click", () => this.openOptions());
     }
 
     const timer = this.timer.querySelector<HTMLElement>(".df-usage-timer");
@@ -353,7 +355,7 @@ export class InterventionUi {
 
     planned.textContent = this.formatClock(options.plannedSeconds);
     platform.textContent = options.platformLabel;
-    daily.textContent = this.formatFriendlyDuration(options.availableSeconds);
+    daily.textContent = this.formatClock(options.availableSeconds);
     timer.dataset.urgent =
       options.plannedSeconds <= 60 || options.availableSeconds <= 60
         ? "true"
@@ -368,131 +370,72 @@ export class InterventionUi {
     this.timer.replaceChildren();
   }
 
-  private showIntentionStep(options: EndOfBatchOptions): void {
-    const card = this.requiredElement<HTMLElement>(".df-card");
-    card.innerHTML = `
-      <p class="df-step">Step 1 of 2</p>
-      <h1>Why do you want to continue?</h1>
-      <div class="df-intentions">
-        ${intentions
-          .map(
-            ([value, label]) => `
-              <button class="df-intention" data-intention="${value}">
-                <span>${label}</span><span aria-hidden="true">→</span>
-              </button>
-            `,
-          )
-          .join("")}
-      </div>
-      <button class="df-settings-link" data-action="back">Back</button>
-    `;
-
-    card
-      .querySelectorAll<HTMLButtonElement>("[data-intention]")
-      .forEach((button) => {
-        button.addEventListener("click", () => this.showHoldStep(options));
-      });
-    this.requiredElement<HTMLButtonElement>('[data-action="back"]')
-      .addEventListener("click", () => this.showEndOfBatch(options));
-  }
-
-  private showHoldStep(options: EndOfBatchOptions): void {
-    const card = this.requiredElement<HTMLElement>(".df-card");
-    card.innerHTML = `
-      <p class="df-step">Step 2 of 2</p>
-      <div class="df-pause-mark" aria-hidden="true"></div>
-      <h1>Pause for a moment.</h1>
-      <p class="df-copy">Then press and hold to open another batch.</p>
-      <button class="df-hold" data-action="hold" disabled style="--df-hold-progress: 0%">
-        <span>Press and hold</span>
-        <span class="df-hold__progress" aria-hidden="true"></span>
-      </button>
-      <p class="df-wait" aria-live="polite"></p>
-      <button class="df-settings-link" data-action="back">Back</button>
-    `;
-
-    const holdButton =
-      this.requiredElement<HTMLButtonElement>('[data-action="hold"]');
-    const waitLabel = this.requiredElement<HTMLElement>(".df-wait");
-    let remaining = options.unlockDelaySeconds;
-
-    const updateWait = () => {
-      waitLabel.textContent =
-        remaining > 0 ? `Available in ${remaining}s` : "Whenever you're ready.";
-    };
-    updateWait();
-
-    const countdown = window.setInterval(() => {
-      remaining -= 1;
-      updateWait();
-      if (remaining <= 0) {
-        window.clearInterval(countdown);
-        holdButton.disabled = false;
-      }
-    }, 1000);
-
-    let holdStarted = 0;
-    let animationFrame = 0;
-    let completed = false;
-
-    const cancelHold = () => {
-      if (completed) return;
-      holdStarted = 0;
-      window.cancelAnimationFrame(animationFrame);
-      holdButton.style.setProperty("--df-hold-progress", "0%");
-    };
-
-    const updateHold = async (now: number) => {
-      const duration = options.holdSeconds * 1000;
-      const progress = Math.min(1, (now - holdStarted) / duration);
-      holdButton.style.setProperty(
-        "--df-hold-progress",
-        `${Math.round(progress * 100)}%`,
-      );
-
-      if (progress >= 1) {
-        completed = true;
-        holdButton.disabled = true;
-        holdButton.querySelector("span")!.textContent = "Preparing…";
-        const granted = await options.onUnlock();
-        if (granted > 0) {
-          this.hide();
-        } else {
-          this.showEndOfBatch({
-            ...options,
-            canUnlock: false,
-            remainingToday: 0,
-          });
-        }
-        return;
-      }
-
-      animationFrame = window.requestAnimationFrame(updateHold);
-    };
-
-    holdButton.addEventListener("pointerdown", (event) => {
-      if (holdButton.disabled) return;
-      event.preventDefault();
-      holdStarted = performance.now();
-      holdButton.setPointerCapture(event.pointerId);
-      animationFrame = window.requestAnimationFrame(updateHold);
-    });
-    holdButton.addEventListener("pointerup", cancelHold);
-    holdButton.addEventListener("pointercancel", cancelHold);
-    holdButton.addEventListener("lostpointercapture", cancelHold);
-
-    this.requiredElement<HTMLButtonElement>('[data-action="back"]')
-      .addEventListener("click", () => {
-        window.clearInterval(countdown);
-        cancelHold();
-        this.showEndOfBatch(options);
-      });
-  }
-
   private requiredElement<T extends Element>(selector: string): T {
     const element = this.overlay.querySelector<T>(selector);
     if (!element) throw new Error(`Missing intervention UI element: ${selector}`);
     return element;
+  }
+
+  private bindTimeStepper(
+    root: ParentNode,
+    maximumMinutes: number,
+    initialMinutes: number,
+    availableSeconds: number,
+    onChange: (label: string) => void,
+  ): { getMinutes(): number; getLabel(): string } {
+    const output = root.querySelector<HTMLOutputElement>(
+      ".df-time-stepper output",
+    );
+    const lessButton = root.querySelector<HTMLButtonElement>(
+      '[data-action="time-less"]',
+    );
+    const moreButton = root.querySelector<HTMLButtonElement>(
+      '[data-action="time-more"]',
+    );
+    if (!output || !lessButton || !moreButton) {
+      throw new Error("Missing session time stepper element");
+    }
+
+    const choices = sessionMinuteChoices(maximumMinutes, initialMinutes);
+    let selectedIndex = Math.max(0, choices.indexOf(initialMinutes));
+
+    const getMinutes = () => choices[selectedIndex] ?? 1;
+    const getLabel = () =>
+      availableSeconds < 60 ? "<1 min" : `${getMinutes()} min`;
+    const render = () => {
+      const label = getLabel();
+      output.value = label;
+      lessButton.disabled = selectedIndex === 0 || availableSeconds < 60;
+      moreButton.disabled =
+        selectedIndex === choices.length - 1 || availableSeconds < 60;
+      onChange(label);
+    };
+
+    lessButton.addEventListener("click", () => {
+      if (selectedIndex === 0) return;
+      selectedIndex -= 1;
+      render();
+    });
+    moreButton.addEventListener("click", () => {
+      if (selectedIndex >= choices.length - 1) return;
+      selectedIndex += 1;
+      render();
+    });
+    render();
+
+    return { getMinutes, getLabel };
+  }
+
+  private openOptions(): void {
+    void browser.runtime.sendMessage<RuntimeMessage>({
+      type: "dopamine-fast:open-options",
+    });
+  }
+
+  private leaveFeed(): void {
+    void browser.runtime.sendMessage<RuntimeMessage>({
+      type: "dopamine-fast:leave-feed",
+    });
   }
 
   private formatClock(totalSeconds: number): string {

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -6,6 +6,7 @@ export interface PlatformAdapter {
   postSelectors: string[];
   suggestedSelectors: string[];
   suggestedTokens: string[];
+  getPostKey(element: HTMLElement): string | undefined;
   isFeedRoute(url: URL): boolean;
 }
 
@@ -14,6 +15,7 @@ const reddit: PlatformAdapter = {
   label: "Reddit",
   postSelectors: [
     "shreddit-post",
+    '[data-testid="post-unit"]',
     '[data-testid="post-container"]',
     'article[data-testid="post"]',
   ],
@@ -31,6 +33,14 @@ const reddit: PlatformAdapter = {
     "recommended for you",
     "recomendado para ti",
   ],
+  getPostKey(element) {
+    return (
+      element.id ||
+      element.getAttribute("thingid") ||
+      element.querySelector<HTMLElement>("shreddit-post[id]")?.id ||
+      undefined
+    );
+  },
   isFeedRoute(url) {
     return (
       !url.pathname.includes("/comments/") &&
@@ -58,6 +68,13 @@ const x: PlatformAdapter = {
     "who to follow",
     "a quién seguir",
   ],
+  getPostKey(element) {
+    const href = element
+      .querySelector<HTMLAnchorElement>('a[href*="/status/"]')
+      ?.getAttribute("href");
+    const match = href?.match(/\/status\/(\d+)/);
+    return match?.[1] ? `status:${match[1]}` : undefined;
+  },
   isFeedRoute(url) {
     return url.pathname === "/home" || url.pathname.startsWith("/i/lists/");
   },
@@ -80,6 +97,15 @@ const instagram: PlatformAdapter = {
     "sponsored",
     "patrocinado",
   ],
+  getPostKey(element) {
+    const href = element
+      .querySelector<HTMLAnchorElement>('a[href^="/p/"], a[href^="/reel/"]')
+      ?.getAttribute("href");
+    const match = href?.match(/^\/(p|reel)\/([^/]+)/);
+    return match?.[1] && match[2]
+      ? `${match[1]}:${match[2]}`
+      : undefined;
+  },
   isFeedRoute(url) {
     return url.pathname === "/";
   },

--- a/lib/runtime-messages.ts
+++ b/lib/runtime-messages.ts
@@ -1,0 +1,55 @@
+import type { PlatformId } from "./models";
+
+export type RuntimeMessage =
+  | {
+      type: "dopamine-fast:reserve-allowance";
+      platform: PlatformId;
+      requested: number;
+      isUnlock: boolean;
+    }
+  | {
+      type: "dopamine-fast:add-usage-seconds";
+      platform: PlatformId;
+      elapsedSeconds: number;
+    }
+  | { type: "dopamine-fast:reset-daily-state" }
+  | { type: "dopamine-fast:open-options" }
+  | { type: "dopamine-fast:leave-feed" };
+
+export interface ReserveAllowanceResponse {
+  granted: number;
+}
+
+export interface AddUsageSecondsResponse {
+  remainingSeconds: number;
+}
+
+export function isRuntimeMessage(value: unknown): value is RuntimeMessage {
+  if (!value || typeof value !== "object" || !("type" in value)) return false;
+  const candidate = value as Record<string, unknown>;
+  switch (candidate.type) {
+    case "dopamine-fast:reserve-allowance":
+      return (
+        isPlatform(candidate.platform) &&
+        isFiniteNumber(candidate.requested) &&
+        typeof candidate.isUnlock === "boolean"
+      );
+    case "dopamine-fast:add-usage-seconds":
+      return (
+        isPlatform(candidate.platform) &&
+        isFiniteNumber(candidate.elapsedSeconds)
+      );
+    case "dopamine-fast:reset-daily-state":
+    case "dopamine-fast:open-options":
+    case "dopamine-fast:leave-feed":
+      return true;
+    default:
+      return false;
+  }
+}
+
+const isPlatform = (value: unknown): value is PlatformId =>
+  value === "reddit" || value === "x" || value === "instagram";
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);

--- a/lib/serial-queue.ts
+++ b/lib/serial-queue.ts
@@ -1,0 +1,12 @@
+export class SerialQueue {
+  private tail = Promise.resolve();
+
+  run<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(operation, operation);
+    this.tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+}

--- a/lib/session-time.ts
+++ b/lib/session-time.ts
@@ -1,0 +1,17 @@
+export function sessionMinuteChoices(
+  maximumMinutes: number,
+  initialMinutes: number,
+): number[] {
+  const maximum = Math.max(1, Math.min(60, Math.round(maximumMinutes)));
+  const initial = Math.max(1, Math.min(maximum, Math.round(initialMinutes)));
+  return [
+    ...new Set([
+      1,
+      initial,
+      maximum,
+      ...Array.from({ length: 12 }, (_, index) => (index + 1) * 5),
+    ]),
+  ]
+    .filter((minutes) => minutes <= maximum)
+    .sort((left, right) => left - right);
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -11,6 +11,11 @@ import {
   type PlatformId,
   type Settings,
 } from "./models";
+import type {
+  AddUsageSecondsResponse,
+  ReserveAllowanceResponse,
+  RuntimeMessage,
+} from "./runtime-messages";
 
 export const settingsItem = storage.defineItem<Settings>(
   "local:dopamine-fast-settings",
@@ -42,6 +47,23 @@ export async function saveSettings(settings: Settings): Promise<void> {
 }
 
 export async function reserveAllowance(
+  platform: PlatformId,
+  requested: number,
+  isUnlock = false,
+): Promise<number> {
+  const response = await browser.runtime.sendMessage<
+    RuntimeMessage,
+    ReserveAllowanceResponse
+  >({
+    type: "dopamine-fast:reserve-allowance",
+    platform,
+    requested,
+    isUnlock,
+  });
+  return response.granted;
+}
+
+export async function reserveAllowanceFromStorage(
   platform: PlatformId,
   requested: number,
   isUnlock = false,
@@ -87,6 +109,21 @@ export async function addUsageSeconds(
   platform: PlatformId,
   elapsedSeconds: number,
 ): Promise<number> {
+  const response = await browser.runtime.sendMessage<
+    RuntimeMessage,
+    AddUsageSecondsResponse
+  >({
+    type: "dopamine-fast:add-usage-seconds",
+    platform,
+    elapsedSeconds,
+  });
+  return response.remainingSeconds;
+}
+
+export async function addUsageSecondsFromStorage(
+  platform: PlatformId,
+  elapsedSeconds: number,
+): Promise<number> {
   const settings = await getSettings();
   const stored = await dailyUsageStateItem.getValue();
   const current = normalizeDailyUsageState(
@@ -113,5 +150,11 @@ export async function addUsageSeconds(
 }
 
 export async function resetDailyState(): Promise<void> {
+  await browser.runtime.sendMessage<RuntimeMessage>({
+    type: "dopamine-fast:reset-daily-state",
+  });
+}
+
+export async function resetDailyStateFromStorage(): Promise<void> {
   await dailyStateItem.setValue(emptyDailyState());
 }

--- a/lib/usage-session.ts
+++ b/lib/usage-session.ts
@@ -73,6 +73,17 @@ export class UsageSession {
     return this.availableSeconds;
   }
 
+  syncAvailableSeconds(availableSeconds: number): void {
+    if (this.state === "destroyed" || this.state === "hard-end") return;
+    this.availableSeconds = Math.min(
+      this.availableSeconds,
+      Math.max(0, Math.round(availableSeconds)),
+    );
+    this.plannedSeconds = Math.min(this.plannedSeconds, this.availableSeconds);
+    this.render();
+    if (this.availableSeconds <= 0) this.finishHardLimit();
+  }
+
   private tick(): void {
     if (this.state !== "running" || document.visibilityState !== "visible") {
       return;

--- a/tests/platforms.test.ts
+++ b/tests/platforms.test.ts
@@ -32,4 +32,21 @@ describe("platform adapters", () => {
       reddit.isFeedRoute(new URL("https://reddit.com/settings/privacy")),
     ).toBe(false);
   });
+
+  it("includes the current narrow Reddit post-unit fallback", () => {
+    const reddit = getPlatformAdapter("reddit.com")!;
+
+    expect(reddit.postSelectors).toContain('[data-testid="post-unit"]');
+  });
+
+  it("uses Reddit's stable post id across virtualized DOM replacements", () => {
+    const reddit = getPlatformAdapter("reddit.com")!;
+    const post = {
+      id: "t3_example",
+      getAttribute: () => null,
+      querySelector: () => null,
+    } as unknown as HTMLElement;
+
+    expect(reddit.getPostKey(post)).toBe("t3_example");
+  });
 });

--- a/tests/runtime-messages.test.ts
+++ b/tests/runtime-messages.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isRuntimeMessage } from "../lib/runtime-messages";
+
+describe("runtime messages", () => {
+  it("accepts valid state and navigation messages", () => {
+    expect(
+      isRuntimeMessage({
+        type: "dopamine-fast:add-usage-seconds",
+        platform: "reddit",
+        elapsedSeconds: 5,
+      }),
+    ).toBe(true);
+    expect(isRuntimeMessage({ type: "dopamine-fast:leave-feed" })).toBe(true);
+  });
+
+  it("rejects malformed and unknown messages", () => {
+    expect(
+      isRuntimeMessage({
+        type: "dopamine-fast:add-usage-seconds",
+        platform: "youtube",
+        elapsedSeconds: 5,
+      }),
+    ).toBe(false);
+    expect(
+      isRuntimeMessage({
+        type: "dopamine-fast:reserve-allowance",
+        platform: "x",
+        requested: Number.POSITIVE_INFINITY,
+        isUnlock: false,
+      }),
+    ).toBe(false);
+    expect(isRuntimeMessage({ type: "dopamine-fast:unknown" })).toBe(false);
+  });
+});

--- a/tests/serial-queue.test.ts
+++ b/tests/serial-queue.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { SerialQueue } from "../lib/serial-queue";
+
+describe("SerialQueue", () => {
+  it("does not overlap state mutations", async () => {
+    const queue = new SerialQueue();
+    const order: string[] = [];
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = queue.run(async () => {
+      order.push("first:start");
+      await firstGate;
+      order.push("first:end");
+    });
+    const second = queue.run(async () => {
+      order.push("second:start");
+      order.push("second:end");
+    });
+
+    await Promise.resolve();
+    expect(order).toEqual(["first:start"]);
+    releaseFirst();
+    await Promise.all([first, second]);
+    expect(order).toEqual([
+      "first:start",
+      "first:end",
+      "second:start",
+      "second:end",
+    ]);
+  });
+
+  it("continues after a failed mutation", async () => {
+    const queue = new SerialQueue();
+    const failed = queue.run(async () => {
+      throw new Error("failed mutation");
+    });
+    const recovered = queue.run(async () => 42);
+
+    await expect(failed).rejects.toThrow("failed mutation");
+    await expect(recovered).resolves.toBe(42);
+  });
+});

--- a/tests/session-time.test.ts
+++ b/tests/session-time.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { sessionMinuteChoices } from "../lib/session-time";
+
+describe("session time choices", () => {
+  it("requires deliberate steps through common five-minute blocks", () => {
+    expect(sessionMinuteChoices(30, 10)).toEqual([
+      1, 5, 10, 15, 20, 25, 30,
+    ]);
+  });
+
+  it("keeps configured and final partial choices available", () => {
+    expect(sessionMinuteChoices(17, 7)).toEqual([1, 5, 7, 10, 15, 17]);
+  });
+});


### PR DESCRIPTION
## What changed

- serialize daily post reservations, time increments, and resets through a background owner
- synchronize the remaining daily timer across active tabs
- make settings navigation reliable and make Leave replace the social tab with a blank tab
- replace session sliders with deliberate button steps and add a 10-second pause before planning another block
- replace the full-screen end-of-batch intervention with an isolated inline load-more gate
- count stable post identities so Reddit DOM virtualization cannot reopen a consumed batch
- clamp scrolling at the inline gate while a batch is closed
- document the verified Reddit DOM, virtualization behavior, real-session evidence, and known limitations

## Why

The previous content-script read/modify/write flow could lose concurrent updates. Session and global timers could diverge across tabs, privileged navigation was unreliable, and the end-of-batch UI interrupted the entire page.

On Reddit, limiting the first N elements in the current DOM was also insufficient because Reddit removes old posts and appends new ones while preserving virtual scroll height. That effectively reset the allowance during a long scroll.

## Impact

Supported feeds now have consistent daily state ownership and more deliberate time extension. Reddit reveals at most the reserved number of unique posts, ends inside the native feed with a load-more control, and requires an explicit wait and hold before revealing the next configured batch.

Post identities remain in memory for the active page only. No post content or identifiers are persisted or transmitted, and no permissions were added.

## Validation

- TypeScript typecheck
- Vitest: 5 files, 17 tests
- Firefox MV2 production build
- Chromium MV3 production build
- Firefox and Chromium ZIP packaging
- authenticated Firefox 153.0.1 desktop smoke test using a temporary copy of the maintainer profile
- forced long-scroll Reddit test: stable identity tracking hid newly virtualized posts and held the inline gate at the feed boundary

## Manual testing gaps

- Firefox for Android was not tested
- Chromium was built and packaged but the final inline Reddit flow was not manually smoke-tested there
- Reddit may continue prefetching hidden data in the background; this change provides finite presentation-layer pagination without intercepting network requests