### PR TITLE
feat(instagram): isolate reels and post budgets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,20 +74,20 @@ On a supported feed route, the content script:
 8. Enforces the daily time ceiling without an in-page extension or reset.
 9. Shows an end-of-batch intervention before revealing more posts.
 
-Post and time budgets intentionally have different scopes:
+Post and time budgets use independent per-network enforcement:
 
-- `DailyState.revealed` and `DailyState.unlocks` are global across all supported
-  networks for the local calendar day.
-- `DailyState.revealedByPlatform` is aggregate reporting data; it does not
-  currently enforce a separate post limit.
+- `DailyState.revealedByPlatform` and `DailyState.unlocksByPlatform` enforce
+  post and unlock limits independently for each supported network.
+- `DailyState.revealed` and `DailyState.unlocks` remain aggregate reporting
+  totals derived from their per-platform records.
 - `DailyUsageState.usedSecondsByPlatform` enforces an independent time ceiling
   for each network.
 - The effective time ceiling is captured when the day's state is created.
   Changing the setting applies on the next local calendar day.
 
 Mode behavior currently differs mainly in unlock policy: balanced mode permits
-two extra batches per day, while gentle and strict are still primarily bounded
-by the global daily post maximum. The stricter fail-closed behavior described
+two extra batches per network per day, while gentle and strict are still
+primarily bounded by the per-network daily post maximum. The stricter fail-closed behavior described
 in `PRODUCT_SPEC.md` is not fully implemented; do not claim otherwise.
 
 ## Technology and extension constraints
@@ -131,6 +131,7 @@ lib/
   usage-history.ts       Pure normalization and retention for usage statistics
   preferred-feed.ts      Optional preferred-feed selection and tab restoration
   intentional-search.ts Search suggestion and discovery-surface suppression
+  single-item-view.ts   Scroll lock for explicitly opened single-item surfaces
   intervention-ui.ts     Shadow-DOM overlays, timer and deliberate interactions
   runtime-messages.ts    Validated background/content message contracts
   serial-queue.ts        Promise queue used by the background state owner
@@ -175,6 +176,8 @@ Specific responsibilities:
   browser or DOM dependencies.
 - `preferred-feed.ts` applies an adapter-defined preferred tab and restores any
   tab styles it changes during teardown.
+- `single-item-view.ts` blocks vertical feed navigation on an explicitly
+  opened item and restores page styles and listeners during teardown.
 - `platforms.ts` is the only home for network-specific hosts, feed routes,
   selectors, stable post identities and recommendation markers.
 - `feed-limiter.ts` may manipulate feed elements, but it must restore every

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -23,7 +23,7 @@ Keep the useful parts of social networks while giving every feed a real end.
 7. The native feed ends with an inline load-more control after the twentieth
    post; no full-screen intervention is shown for a batch boundary.
 8. The user can deliberately reveal 10 additional posts from that control.
-9. Daily hard limits for both time and posts stop further use.
+9. Per-network daily hard limits for both time and posts stop further use.
 
 ## Time budgets
 
@@ -56,7 +56,7 @@ Keep the useful parts of social networks while giving every feed a real end.
 ## Unlock flow
 
 The end of a batch is rendered inside the native feed. The inline control shows
-how many posts remain in the daily allowance, waits through the configured
+how many posts remain in that network's daily allowance, waits through the configured
 pause and requires holding the load-more button for the configured duration.
 Completing it reveals only the next configured batch.
 Virtualized feeds are counted by stable post identity for the active page
@@ -76,7 +76,7 @@ visible area while the batch is closed.
 
 ### Balanced
 
-- One initial batch and two additional batches.
+- One initial batch and two additional batches per network.
 - The inline pause and hold are required.
 
 ### Strict
@@ -116,6 +116,9 @@ visible area while the batch is closed.
 - Keep followed-account posts and direct profile visits.
 - Hide suggested posts, Explore recommendations, Reels surfaces and promoted
   posts.
+- Hide the generic Reels navigation destination. When an individual reel or
+  the Reels route is opened directly, keep the first opened item usable while
+  blocking vertical wheel, keyboard and touch navigation to another reel.
 - Stop after the active batch or after Instagram's own caught-up marker,
   whichever comes first.
 

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -114,6 +114,8 @@ visible area while the batch is closed.
 ### Instagram
 
 - Keep followed-account posts and direct profile visits.
+- When the optional Following-only setting is enabled, select Following and
+  hide For You while the home feed is active.
 - Hide suggested posts, Explore recommendations, Reels surfaces and promoted
   posts.
 - Hide the generic Reels navigation destination. When an individual reel or

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ available while adding deliberate friction around habitual scrolling:
 6. Reaching the end shows an inline control for loading the next batch.
 7. A per-network daily time ceiling cannot be extended from the page.
 
-Daily post allowances are shared across supported networks. Daily time
-ceilings are tracked independently for Reddit, X/Twitter, and Instagram.
+Daily post allowances and time ceilings are tracked independently for Reddit,
+X/Twitter, and Instagram.
 Preferences and aggregate counters stay in browser extension local storage.
 Elapsed seconds per network are retained for the 30 most recent days with
 activity; active session countdowns are not stored in that history.
@@ -54,6 +54,8 @@ of loading more posts automatically.
 - Intentional search on X and Reddit: autocomplete is suppressed, and X Explore
   stays empty until a query is submitted. X result tabs and Reddit's Popular,
   News and Explore shortcuts are also hidden.
+- Instagram's Reels destination is hidden; a directly opened reel remains
+  usable without vertical navigation into an endless sequence.
 - Non-extendable daily time ceiling for each network.
 - Finite initial and additional post batches.
 - Stable per-session post counting for virtualized feeds such as Reddit.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ of loading more posts automatically.
 - Configurable delay before entering a supported feed.
 - Intentional session duration, adjusted through deliberate button steps, with
   a persistent floating countdown.
-- Optional Following-only mode for X that selects Following and hides For You.
+- Optional Following-only modes for X and Instagram that select Following and
+  hide For You.
 - Intentional search on X and Reddit: autocomplete is suppressed, and X Explore
   stays empty until a query is submitted. X result tabs and Reddit's Popular,
   News and Explore shortcuts are also hidden.

--- a/docs/INSTAGRAM_ADAPTER_NOTES.md
+++ b/docs/INSTAGRAM_ADAPTER_NOTES.md
@@ -1,0 +1,52 @@
+# Instagram adapter notes
+
+This document records authenticated DOM observations used by the Instagram
+adapter. Selectors here are deliberately scoped to the relevant route because
+Instagram's structure changes frequently.
+
+## Verified environment
+
+- Date: 2026-08-04
+- Browser: authenticated Chrome desktop session on Windows
+- Page language: Spanish
+- Pages: `https://www.instagram.com/` and an observed `/reels/{id}/` link
+- Observed viewport: 1175 by 827 CSS pixels
+
+Firefox MV2 and Chromium MV3 production builds were validated, but the signed-in
+selector inspection used Chrome. Mobile Instagram remains a manual testing gap.
+
+## Reels navigation
+
+The desktop sidebar exposed its generic Reels destination as an exact
+`a[href="/reels/"]` link. The adapter hides that destination independently of
+the general suggestion setting. It does not hide account-specific `/reels/`
+links or reel links embedded in requested content.
+
+## Direct reel route
+
+Instagram currently uses both `/reel/{id}/` and `/reels/{id}/` shapes. The
+authenticated feed exposed the plural form. A direct plural route immediately
+rendered five `[role="group"][aria-label="Video player"]` elements even without
+scrolling and exposed a `main [role="toolbar"]` with previous/next controls.
+
+Each video group was nested inside a route-local item container carrying an
+inline `--x-height` property. On a direct reel route the controller therefore:
+
+- retains the first visible item container;
+- hides other preloaded item containers and the Reels navigation toolbar;
+- blocks wheel, touch and vertical keyboard navigation;
+- observes later DOM additions and applies the same boundary; and
+- restores every changed inline style, listener and observer on teardown.
+
+This is a presentation-layer boundary. Instagram may still prefetch additional
+media, and the extension does not intercept requests or use Instagram APIs.
+
+## Manual verification checklist
+
+1. Reload the unpacked extension after building the Chromium target.
+2. Confirm the generic Reels link is absent from the Instagram sidebar.
+3. Open a reel through a user-requested post or direct URL.
+4. Confirm the opened reel remains playable and its normal action buttons work.
+5. Try wheel, touchpad, Page Down, arrow keys and the previous/next controls;
+   none should expose another reel.
+6. Navigate back to the home feed and confirm page scrolling is restored.

--- a/docs/INSTAGRAM_ADAPTER_NOTES.md
+++ b/docs/INSTAGRAM_ADAPTER_NOTES.md
@@ -41,6 +41,15 @@ inline `--x-height` property. On a direct reel route the controller therefore:
 This is a presentation-layer boundary. Instagram may still prefetch additional
 media, and the extension does not intercept requests or use Instagram APIs.
 
+## Following-only feed
+
+The authenticated home feed exposed `Para ti` and `Siguiendo` as two
+`[role="tab"]` elements inside a `main [role="tablist"]`. Both used
+`aria-selected` to identify the active feed. The optional Following-only mode
+uses that scoped contract to select `Following` or `Siguiendo` and hide only
+the exact `For you` or `Para ti` tab. The hidden tab's original inline display
+style is restored during teardown.
+
 ## Manual verification checklist
 
 1. Reload the unpacked extension after building the Chromium target.

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -114,7 +114,10 @@ export default defineContentScript({
 
       if (!adapter.isFeedRoute(url)) return;
 
-      if (adapter.id === "x" && settings.xFollowingOnly) {
+      const followingOnly =
+        (adapter.id === "x" && settings.xFollowingOnly) ||
+        (adapter.id === "instagram" && settings.instagramFollowingOnly);
+      if (followingOnly) {
         preferredFeed = new PreferredFeedController(adapter);
         preferredFeed.start();
       }

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -5,6 +5,7 @@ import { IntentionalSearchController } from "../lib/intentional-search";
 import { availableUsageSeconds, localDateKey } from "../lib/models";
 import { getPlatformAdapter } from "../lib/platforms";
 import { PreferredFeedController } from "../lib/preferred-feed";
+import { SingleItemViewController } from "../lib/single-item-view";
 import {
   getDailyUsageState,
   getSettings,
@@ -64,6 +65,7 @@ export default defineContentScript({
     let limiter: FeedLimiter | undefined;
     let intentionalSearch: IntentionalSearchController | undefined;
     let preferredFeed: PreferredFeedController | undefined;
+    let singleItemView: SingleItemViewController | undefined;
     let usageSession: UsageSession | undefined;
     let currentUrl = "";
     let activationId = 0;
@@ -76,6 +78,8 @@ export default defineContentScript({
       intentionalSearch = undefined;
       preferredFeed?.destroy();
       preferredFeed = undefined;
+      singleItemView?.destroy();
+      singleItemView = undefined;
       const previousUsageSession = usageSession;
       usageSession = undefined;
       await previousUsageSession?.destroy();
@@ -89,9 +93,23 @@ export default defineContentScript({
         return;
       }
 
-      if (settings.blockSuggested && adapter.intentionalSearch) {
-        intentionalSearch = new IntentionalSearchController(adapter, url);
+      if (
+        adapter.intentionalSearch &&
+        (settings.blockSuggested ||
+          adapter.intentionalSearch.alwaysHideNavigation)
+      ) {
+        intentionalSearch = new IntentionalSearchController(
+          adapter,
+          url,
+          settings.blockSuggested,
+        );
         intentionalSearch.start();
+      }
+
+      if (adapter.singleItemView?.isRoute(url)) {
+        singleItemView = new SingleItemViewController(adapter.singleItemView);
+        singleItemView.start();
+        return;
       }
 
       if (!adapter.isFeedRoute(url)) return;
@@ -225,6 +243,7 @@ export default defineContentScript({
       limiter?.destroy();
       intentionalSearch?.destroy();
       preferredFeed?.destroy();
+      singleItemView?.destroy();
       void usageSession?.destroy();
       shadowUi.remove();
     });

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -209,6 +209,7 @@
             <label><span>X / Twitter</span><input id="site-x" type="checkbox" /></label>
             <label><span>X: Following only</span><input id="x-following-only" type="checkbox" /></label>
             <label><span>Instagram</span><input id="site-instagram" type="checkbox" /></label>
+            <label><span>Instagram: Following only</span><input id="instagram-following-only" type="checkbox" /></label>
             <label><span>Hide suggestions</span><input id="block-suggested" type="checkbox" /></label>
             <label><span>Stop autoplay</span><input id="disable-autoplay" type="checkbox" /></label>
           </div>

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -147,7 +147,7 @@
                 max="500"
                 step="10"
               />
-              <small>across all networks</small>
+              <small>posts per network</small>
             </label>
           </div>
         </section>

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -35,6 +35,9 @@ const controls = {
   x: requiredElement<HTMLInputElement>("#site-x"),
   xFollowingOnly: requiredElement<HTMLInputElement>("#x-following-only"),
   instagram: requiredElement<HTMLInputElement>("#site-instagram"),
+  instagramFollowingOnly: requiredElement<HTMLInputElement>(
+    "#instagram-following-only",
+  ),
   blockSuggested: requiredElement<HTMLInputElement>("#block-suggested"),
   disableAutoplay: requiredElement<HTMLInputElement>("#disable-autoplay"),
 };
@@ -65,6 +68,7 @@ function render(settings: Settings): void {
   controls.x.checked = settings.enabledSites.x;
   controls.xFollowingOnly.checked = settings.xFollowingOnly;
   controls.instagram.checked = settings.enabledSites.instagram;
+  controls.instagramFollowingOnly.checked = settings.instagramFollowingOnly;
   controls.blockSuggested.checked = settings.blockSuggested;
   controls.disableAutoplay.checked = settings.disableAutoplay;
   requiredElement<HTMLInputElement>(
@@ -92,6 +96,7 @@ function readSettings(): Settings {
     blockSuggested: controls.blockSuggested.checked,
     disableAutoplay: controls.disableAutoplay.checked,
     xFollowingOnly: controls.xFollowingOnly.checked,
+    instagramFollowingOnly: controls.instagramFollowingOnly.checked,
     enabledSites: {
       reddit: controls.reddit.checked,
       x: controls.x.checked,
@@ -107,6 +112,14 @@ function readSettings(): Settings {
 controls.xFollowingOnly.addEventListener("change", async () => {
   await saveSettings(readSettings());
   status.textContent = "X feed preference applied.";
+  window.setTimeout(() => {
+    status.textContent = "";
+  }, 2400);
+});
+
+controls.instagramFollowingOnly.addEventListener("change", async () => {
+  await saveSettings(readSettings());
+  status.textContent = "Instagram feed preference applied.";
   window.setTimeout(() => {
     status.textContent = "";
   }, 2400);

--- a/lib/feed-limiter.ts
+++ b/lib/feed-limiter.ts
@@ -160,9 +160,14 @@ export class FeedLimiter {
   ): Promise<void> {
     const state = normalizeDailyState(await dailyStateItem.getValue());
     if (this.destroyed || requestId !== this.gateRequestId) return;
-    const remainingToday = availableAllowance(this.settings, state);
+    const remainingToday = availableAllowance(
+      this.settings,
+      state,
+      this.adapter.id,
+    );
     const balancedUnlockAvailable =
-      this.settings.mode !== "balanced" || state.unlocks < 2;
+      this.settings.mode !== "balanced" ||
+      state.unlocksByPlatform[this.adapter.id] < 2;
     const canUnlock = remainingToday > 0 && balancedUnlockAvailable;
 
     const showGate = placement === "after"

--- a/lib/intentional-search.ts
+++ b/lib/intentional-search.ts
@@ -16,6 +16,7 @@ export class IntentionalSearchController {
   constructor(
     private readonly adapter: PlatformAdapter,
     private readonly url: URL,
+    private readonly suppressSuggestions = true,
   ) {}
 
   start(): void {
@@ -53,21 +54,25 @@ export class IntentionalSearchController {
     );
     [...roots, ...navigationRoots].forEach((root) => this.observe(root));
     const shadowRoots = roots.slice(1);
-    this.hideMatches([document], config.suggestionSelectors);
-    this.hideMatches(shadowRoots, config.shadowSuggestionSelectors ?? []);
-    this.hideControlledPopups([document], roots, config.inputSelectors);
-    this.hideControlledPopups(
-      shadowRoots,
-      roots,
-      config.shadowInputSelectors ?? [],
-    );
-    this.hideMatches([document], config.navigationSelectors ?? []);
-    this.hideMatches(
-      navigationRoots.slice(1),
-      config.shadowNavigationSelectors ?? [],
-    );
+    if (this.suppressSuggestions) {
+      this.hideMatches([document], config.suggestionSelectors);
+      this.hideMatches(shadowRoots, config.shadowSuggestionSelectors ?? []);
+      this.hideControlledPopups([document], roots, config.inputSelectors);
+      this.hideControlledPopups(
+        shadowRoots,
+        roots,
+        config.shadowInputSelectors ?? [],
+      );
+      this.hideMatches([document], selectorsForRoute(config, this.url));
+    }
 
-    this.hideMatches([document], selectorsForRoute(config, this.url));
+    if (this.suppressSuggestions || config.alwaysHideNavigation) {
+      this.hideMatches([document], config.navigationSelectors ?? []);
+      this.hideMatches(
+        navigationRoots.slice(1),
+        config.shadowNavigationSelectors ?? [],
+      );
+    }
   }
 
   private observe(root: Node): void {

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -15,6 +15,7 @@ export interface Settings {
   blockSuggested: boolean;
   disableAutoplay: boolean;
   xFollowingOnly: boolean;
+  instagramFollowingOnly: boolean;
   enabledSites: Record<PlatformId, boolean>;
 }
 
@@ -46,6 +47,7 @@ export const DEFAULT_SETTINGS: Settings = {
   blockSuggested: true,
   disableAutoplay: true,
   xFollowingOnly: false,
+  instagramFollowingOnly: false,
   enabledSites: {
     reddit: true,
     x: true,
@@ -110,6 +112,10 @@ export function sanitizeSettings(input: Partial<Settings>): Settings {
       typeof input.xFollowingOnly === "boolean"
         ? input.xFollowingOnly
         : DEFAULT_SETTINGS.xFollowingOnly,
+    instagramFollowingOnly:
+      typeof input.instagramFollowingOnly === "boolean"
+        ? input.instagramFollowingOnly
+        : DEFAULT_SETTINGS.instagramFollowingOnly,
     enabledSites: {
       ...DEFAULT_SETTINGS.enabledSites,
       ...input.enabledSites,

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -23,6 +23,7 @@ export interface DailyState {
   revealed: number;
   revealedByPlatform: Record<PlatformId, number>;
   unlocks: number;
+  unlocksByPlatform: Record<PlatformId, number>;
 }
 
 export interface DailyUsageState {
@@ -133,14 +134,29 @@ export function emptyDailyState(date = new Date()): DailyState {
       instagram: 0,
     },
     unlocks: 0,
+    unlocksByPlatform: {
+      reddit: 0,
+      x: 0,
+      instagram: 0,
+    },
   };
 }
 
 export function normalizeDailyState(
-  state: DailyState | null,
+  state: Partial<DailyState> | null,
   date = new Date(),
 ): DailyState {
-  return state?.date === localDateKey(date) ? state : emptyDailyState(date);
+  if (state?.date !== localDateKey(date)) return emptyDailyState(date);
+
+  const revealedByPlatform = normalizePlatformCounts(state.revealedByPlatform);
+  const unlocksByPlatform = normalizePlatformCounts(state.unlocksByPlatform);
+  return {
+    date: state.date,
+    revealed: sumPlatformCounts(revealedByPlatform),
+    revealedByPlatform,
+    unlocks: sumPlatformCounts(unlocksByPlatform),
+    unlocksByPlatform,
+  };
 }
 
 export function emptyDailyUsageState(
@@ -193,6 +209,28 @@ export function availableUsageSeconds(
 export function availableAllowance(
   settings: Settings,
   state: DailyState,
+  platform: PlatformId,
 ): number {
-  return Math.max(0, settings.dailyLimit - state.revealed);
+  return Math.max(
+    0,
+    settings.dailyLimit - state.revealedByPlatform[platform],
+  );
+}
+
+function normalizePlatformCounts(
+  counts: Partial<Record<PlatformId, number>> | undefined,
+): Record<PlatformId, number> {
+  return {
+    reddit: normalizeCount(counts?.reddit),
+    x: normalizeCount(counts?.x),
+    instagram: normalizeCount(counts?.instagram),
+  };
+}
+
+function normalizeCount(value: number | undefined): number {
+  return Number.isFinite(value) ? Math.max(0, Math.round(value ?? 0)) : 0;
+}
+
+function sumPlatformCounts(counts: Record<PlatformId, number>): number {
+  return counts.reddit + counts.x + counts.instagram;
 }

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -14,6 +14,7 @@ export interface PlatformAdapter {
   intentionalSearch?: {
     inputSelectors: string[];
     suggestionSelectors: string[];
+    alwaysHideNavigation?: boolean;
     shadowHostSelectors?: string[];
     shadowInputSelectors?: string[];
     shadowSuggestionSelectors?: string[];
@@ -24,6 +25,12 @@ export interface PlatformAdapter {
       selectors: string[];
     }>;
     navigationSelectors?: string[];
+  };
+  singleItemView?: {
+    isRoute(url: URL): boolean;
+    itemSelector: string;
+    itemRootSelector: string;
+    navigationSelectors: string[];
   };
   getPostKey(element: HTMLElement): string | undefined;
   isFeedRoute(url: URL): boolean;
@@ -187,13 +194,37 @@ const instagram: PlatformAdapter = {
     "sponsored",
     "patrocinado",
   ],
+  intentionalSearch: {
+    inputSelectors: [],
+    suggestionSelectors: [],
+    alwaysHideNavigation: true,
+    navigationSelectors: [
+      'a[href="/reels/"]',
+      'nav a[href^="/reels/"]',
+      '[role="navigation"] a[href^="/reels/"]',
+    ],
+  },
+  singleItemView: {
+    isRoute(url) {
+      return (
+        url.pathname === "/reels/" ||
+        /^\/reels?\/[^/]+\/?$/.test(url.pathname)
+      );
+    },
+    itemSelector: 'main [role="group"][aria-label="Video player"]',
+    itemRootSelector: '[style*="--x-height"]',
+    navigationSelectors: ['main [role="toolbar"]'],
+  },
   getPostKey(element) {
     const href = element
-      .querySelector<HTMLAnchorElement>('a[href^="/p/"], a[href^="/reel/"]')
+      .querySelector<HTMLAnchorElement>(
+        'a[href^="/p/"], a[href^="/reel/"], a[href^="/reels/"]',
+      )
       ?.getAttribute("href");
-    const match = href?.match(/^\/(p|reel)\/([^/]+)/);
+    const match = href?.match(/^\/(p|reels?)\/([^/]+)/);
+    const type = match?.[1] === "reels" ? "reel" : match?.[1];
     return match?.[1] && match[2]
-      ? `${match[1]}:${match[2]}`
+      ? `${type}:${match[2]}`
       : undefined;
   },
   isFeedRoute(url) {

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -194,6 +194,11 @@ const instagram: PlatformAdapter = {
     "sponsored",
     "patrocinado",
   ],
+  preferredFeed: {
+    tabSelector: 'main [role="tablist"] [role="tab"]',
+    preferredTokens: ["following", "siguiendo"],
+    hiddenTokens: ["for you", "para ti"],
+  },
   intentionalSearch: {
     inputSelectors: [],
     suggestionSelectors: [],

--- a/lib/single-item-view.ts
+++ b/lib/single-item-view.ts
@@ -1,0 +1,179 @@
+interface OriginalProperty {
+  value: string;
+  priority: string;
+}
+
+interface OriginalPageStyles {
+  overflow: OriginalProperty;
+  overscrollBehavior: OriginalProperty;
+}
+
+interface SingleItemViewOptions {
+  itemSelector: string;
+  itemRootSelector: string;
+  navigationSelectors: string[];
+}
+
+const BLOCKED_KEYS = new Set([
+  "ArrowDown",
+  "ArrowUp",
+  "End",
+  "Home",
+  "PageDown",
+  "PageUp",
+  " ",
+]);
+
+export class SingleItemViewController {
+  private readonly originals = new Map<HTMLElement, OriginalPageStyles>();
+  private readonly originalDisplays = new Map<HTMLElement, OriginalProperty>();
+  private observer: MutationObserver | undefined;
+  private primaryItem: HTMLElement | undefined;
+  private scanTimer: number | undefined;
+  private started = false;
+
+  constructor(private readonly options: SingleItemViewOptions) {}
+
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    this.lock(document.documentElement);
+    if (document.body) this.lock(document.body);
+    window.addEventListener("wheel", this.blockPointerNavigation, {
+      capture: true,
+      passive: false,
+    });
+    window.addEventListener("touchmove", this.blockPointerNavigation, {
+      capture: true,
+      passive: false,
+    });
+    window.addEventListener("keydown", this.blockKeyboardNavigation, true);
+    this.enforceSingleItem();
+    this.observer = new MutationObserver(() => this.scheduleScan());
+    this.observer.observe(document.body, { childList: true, subtree: true });
+  }
+
+  destroy(): void {
+    if (!this.started) return;
+    this.started = false;
+    window.removeEventListener("wheel", this.blockPointerNavigation, true);
+    window.removeEventListener("touchmove", this.blockPointerNavigation, true);
+    window.removeEventListener("keydown", this.blockKeyboardNavigation, true);
+    this.observer?.disconnect();
+    this.observer = undefined;
+    if (this.scanTimer !== undefined) window.clearTimeout(this.scanTimer);
+    this.scanTimer = undefined;
+    this.originals.forEach((styles, element) => {
+      restoreProperty(element, "overflow", styles.overflow);
+      restoreProperty(
+        element,
+        "overscroll-behavior",
+        styles.overscrollBehavior,
+      );
+    });
+    this.originals.clear();
+    this.originalDisplays.forEach((display, element) => {
+      restoreProperty(element, "display", display);
+    });
+    this.originalDisplays.clear();
+    this.primaryItem = undefined;
+  }
+
+  private readonly blockPointerNavigation = (event: Event): void => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  private readonly blockKeyboardNavigation = (event: KeyboardEvent): void => {
+    if (
+      !isBlockedSingleItemNavigationKey(event.key) ||
+      isAllowedInteractionTarget(event.target)
+    ) {
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  private lock(element: HTMLElement): void {
+    if (!this.originals.has(element)) {
+      this.originals.set(element, {
+        overflow: originalProperty(element, "overflow"),
+        overscrollBehavior: originalProperty(element, "overscroll-behavior"),
+      });
+    }
+    element.style.setProperty("overflow", "hidden", "important");
+    element.style.setProperty("overscroll-behavior", "none", "important");
+  }
+
+  private scheduleScan(): void {
+    if (this.scanTimer !== undefined) return;
+    this.scanTimer = window.setTimeout(() => {
+      this.scanTimer = undefined;
+      this.enforceSingleItem();
+    }, 50);
+  }
+
+  private enforceSingleItem(): void {
+    const items = Array.from(
+      document.querySelectorAll<HTMLElement>(this.options.itemSelector),
+    )
+      .map((item) => item.closest<HTMLElement>(this.options.itemRootSelector))
+      .filter((item): item is HTMLElement => item !== null);
+    const uniqueItems = [...new Set(items)];
+
+    this.primaryItem ??= uniqueItems.find(isVisible) ?? uniqueItems[0];
+    uniqueItems.forEach((item) => {
+      if (item !== this.primaryItem) this.hide(item);
+    });
+
+    this.options.navigationSelectors.forEach((selector) => {
+      document
+        .querySelectorAll<HTMLElement>(selector)
+        .forEach((element) => this.hide(element));
+    });
+  }
+
+  private hide(element: HTMLElement): void {
+    if (!this.originalDisplays.has(element)) {
+      this.originalDisplays.set(element, originalProperty(element, "display"));
+    }
+    element.style.setProperty("display", "none", "important");
+  }
+}
+
+export function isBlockedSingleItemNavigationKey(key: string): boolean {
+  return BLOCKED_KEYS.has(key);
+}
+
+function isAllowedInteractionTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  return Boolean(
+    target.closest(
+      'input, textarea, select, [contenteditable="true"]',
+    ),
+  );
+}
+
+function isVisible(element: HTMLElement): boolean {
+  const rect = element.getBoundingClientRect();
+  return rect.bottom > 0 && rect.top < window.innerHeight;
+}
+
+function originalProperty(
+  element: HTMLElement,
+  property: string,
+): OriginalProperty {
+  return {
+    value: element.style.getPropertyValue(property),
+    priority: element.style.getPropertyPriority(property),
+  };
+}
+
+function restoreProperty(
+  element: HTMLElement,
+  property: string,
+  original: OriginalProperty,
+): void {
+  element.style.setProperty(property, original.value, original.priority);
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -86,7 +86,10 @@ export async function reserveAllowanceFromStorage(
   const current = normalizeDailyState(stored);
   const granted = Math.min(
     Math.max(0, requested),
-    Math.max(0, settings.dailyLimit - current.revealed),
+    Math.max(
+      0,
+      settings.dailyLimit - current.revealedByPlatform[platform],
+    ),
   );
 
   if (granted === 0) {
@@ -104,6 +107,10 @@ export async function reserveAllowanceFromStorage(
       [platform]: current.revealedByPlatform[platform] + granted,
     },
     unlocks: current.unlocks + (isUnlock ? 1 : 0),
+    unlocksByPlatform: {
+      ...current.unlocksByPlatform,
+      [platform]: current.unlocksByPlatform[platform] + (isUnlock ? 1 : 0),
+    },
   });
 
   return granted;

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -61,11 +61,42 @@ describe("daily state", () => {
   it("calculates the remaining allowance", () => {
     const state = {
       ...emptyDailyState(today),
-      revealed: 35,
+      revealed: 45,
+      revealedByPlatform: {
+        reddit: 35,
+        x: 10,
+        instagram: 0,
+      },
     };
     expect(
-      availableAllowance({ ...DEFAULT_SETTINGS, dailyLimit: 60 }, state),
+      availableAllowance(
+        { ...DEFAULT_SETTINGS, dailyLimit: 60 },
+        state,
+        "reddit",
+      ),
     ).toBe(25);
+    expect(
+      availableAllowance(
+        { ...DEFAULT_SETTINGS, dailyLimit: 60 },
+        state,
+        "instagram",
+      ),
+    ).toBe(60);
+  });
+
+  it("migrates legacy daily state to per-network unlock counters", () => {
+    const legacy = {
+      date: localDateKey(today),
+      revealed: 30,
+      revealedByPlatform: { reddit: 20, x: 10, instagram: 0 },
+      unlocks: 2,
+    };
+
+    expect(normalizeDailyState(legacy, today)).toEqual({
+      ...legacy,
+      unlocks: 0,
+      unlocksByPlatform: { reddit: 0, x: 0, instagram: 0 },
+    });
   });
 
   it("resets stale time usage and calculates a per-network hard limit", () => {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -22,6 +22,7 @@ describe("settings", () => {
       dailyLimit: -10,
       holdSeconds: 0,
       xFollowingOnly: "yes" as unknown as boolean,
+      instagramFollowingOnly: "yes" as unknown as boolean,
     });
 
     expect(settings.openingDelaySeconds).toBe(60);
@@ -32,6 +33,7 @@ describe("settings", () => {
     expect(settings.dailyLimit).toBe(10);
     expect(settings.holdSeconds).toBe(1);
     expect(settings.xFollowingOnly).toBe(false);
+    expect(settings.instagramFollowingOnly).toBe(false);
     expect(settings.enabledSites).toEqual(DEFAULT_SETTINGS.enabledSites);
   });
 
@@ -39,6 +41,13 @@ describe("settings", () => {
     expect(sanitizeSettings({ xFollowingOnly: true }).xFollowingOnly).toBe(
       true,
     );
+  });
+
+  it("keeps an explicit Instagram Following preference", () => {
+    expect(
+      sanitizeSettings({ instagramFollowingOnly: true })
+        .instagramFollowingOnly,
+    ).toBe(true);
   });
 });
 

--- a/tests/platforms.test.ts
+++ b/tests/platforms.test.ts
@@ -33,6 +33,43 @@ describe("platform adapters", () => {
     ).toBe(false);
   });
 
+  it("recognizes Instagram reel routes as single-item views", () => {
+    const instagram = getPlatformAdapter("instagram.com")!;
+
+    expect(
+      instagram.singleItemView?.isRoute(
+        new URL("https://instagram.com/reel/ABC123/"),
+      ),
+    ).toBe(true);
+    expect(
+      instagram.singleItemView?.isRoute(
+        new URL("https://instagram.com/reels/ABC123/"),
+      ),
+    ).toBe(true);
+    expect(
+      instagram.singleItemView?.isRoute(
+        new URL("https://instagram.com/reels/"),
+      ),
+    ).toBe(true);
+    expect(
+      instagram.singleItemView?.isRoute(
+        new URL("https://instagram.com/direct/inbox/"),
+      ),
+    ).toBe(false);
+  });
+
+  it("hides Instagram's generic Reels navigation destination", () => {
+    const instagram = getPlatformAdapter("instagram.com")!;
+
+    expect(instagram.intentionalSearch?.navigationSelectors).toContain(
+      'a[href="/reels/"]',
+    );
+    expect(instagram.intentionalSearch?.alwaysHideNavigation).toBe(true);
+    expect(instagram.singleItemView?.navigationSelectors).toContain(
+      'main [role="toolbar"]',
+    );
+  });
+
   it("includes the current narrow Reddit post-unit fallback", () => {
     const reddit = getPlatformAdapter("reddit.com")!;
 

--- a/tests/platforms.test.ts
+++ b/tests/platforms.test.ts
@@ -70,6 +70,16 @@ describe("platform adapters", () => {
     );
   });
 
+  it("defines Instagram's Following feed tabs narrowly", () => {
+    const instagram = getPlatformAdapter("instagram.com")!;
+
+    expect(instagram.preferredFeed).toEqual({
+      tabSelector: 'main [role="tablist"] [role="tab"]',
+      preferredTokens: ["following", "siguiendo"],
+      hiddenTokens: ["for you", "para ti"],
+    });
+  });
+
   it("includes the current narrow Reddit post-unit fallback", () => {
     const reddit = getPlatformAdapter("reddit.com")!;
 

--- a/tests/single-item-view.test.ts
+++ b/tests/single-item-view.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { isBlockedSingleItemNavigationKey } from "../lib/single-item-view";
+
+describe("single item view", () => {
+  it("blocks vertical feed navigation while preserving media controls", () => {
+    expect(isBlockedSingleItemNavigationKey("ArrowDown")).toBe(true);
+    expect(isBlockedSingleItemNavigationKey("PageDown")).toBe(true);
+    expect(isBlockedSingleItemNavigationKey(" ")).toBe(true);
+    expect(isBlockedSingleItemNavigationKey("ArrowLeft")).toBe(false);
+    expect(isBlockedSingleItemNavigationKey("Enter")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

- enforce daily post allowances independently for Reddit, X, and Instagram
- enforce balanced-mode extra batch counters independently per network
- add an optional Instagram Following-only setting that selects Following/Siguiendo and hides For You/Para ti
- hide Instagram's generic Reels navigation destination
- keep only the initially opened reel available on direct `/reel/{id}/` and `/reels/{id}/` routes
- block wheel, touch, vertical keyboard navigation, and Instagram's previous/next Reels toolbar
- restore all modified styles, observers, and listeners when leaving the route
- document the authenticated Instagram DOM inspection and update product behavior docs

## Why

Post limits were still shared globally even though time limits and usage metrics are per network. Authenticated Instagram inspection also showed that one direct reel URL preloaded five video groups and exposed previous/next controls. The home feed exposed stable semantic tabs for Para ti and Siguiendo, allowing the existing deliberate-feed controller to support Instagram without broad selectors.

## Privacy and permissions

No permissions, remote services, content collection, request interception, or platform APIs were added. State remains local and contains only preferences and aggregate counters.

## Validation

- TypeScript strict check
- 11 Vitest files / 36 tests
- Firefox MV2 production build
- Chromium MV3 production build
- signed-in Chrome Instagram inspection at 1175 by 827 CSS pixels
- verified semantic `main [role="tablist"] [role="tab"]` feed tabs with `aria-selected`
- verified the plural `/reels/{id}/` route, five preloaded video groups, and the Reels navigation toolbar contract

## Manual testing still needed

- reload the unpacked Chromium build and confirm Following-only and Reels isolation behavior
- Instagram mobile selector verification
- Firefox Android smoke test
