### PR TITLE
fix(ui): remove unsafe HTML assignments

### DIFF
--- a/lib/intervention-ui.ts
+++ b/lib/intervention-ui.ts
@@ -1,5 +1,12 @@
 import type { RuntimeMessage } from "./runtime-messages";
 import { sessionMinuteChoices } from "./session-time";
+import {
+  createHardLimitView,
+  createOpeningView,
+  createSessionEndedView,
+  createSessionPlanningView,
+  createUsageTimerView,
+} from "./intervention-views";
 
 export interface OpeningOptions {
   platformLabel: string;
@@ -66,60 +73,18 @@ export class InterventionUi {
     );
     const defaultSessionLabel =
       options.availableSeconds < 60 ? "<1 min" : `${defaultMinutes} min`;
-    this.overlay.innerHTML = `
-      <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-opening-title">
-        <article class="df-card df-card--opening">
-          <p class="df-kicker">A pause before entering</p>
-          ${
-            options.delaySeconds > 0
-              ? `<div class="df-countdown" aria-live="polite">${options.delaySeconds}</div>`
-              : `<div class="df-pause-mark df-pause-mark--centered" aria-hidden="true"></div>`
-          }
-          <h1 id="df-opening-title">How much time do you want to spend on ${options.platformLabel}?</h1>
-          <p class="df-copy">
-            Choose a defined session now. The timer will remain visible as you browse.
-          </p>
-          <section class="df-usage-summary" aria-labelledby="df-usage-summary-title">
-            <p id="df-usage-summary-title">Time spent today</p>
-            <div class="df-usage-summary__items">
-              ${options.usageMetrics
-                .map(
-                  (metric) => `
-                    <div class="df-usage-summary__item">
-                      <span>${metric.label}</span>
-                      <strong>${this.formatUsageDuration(metric.usedSeconds)}</strong>
-                    </div>
-                  `,
-                )
-                .join("")}
-            </div>
-          </section>
-          <div class="df-time-choice df-time-stepper">
-            <span>This session</span>
-            <output aria-live="polite">${defaultSessionLabel}</output>
-            <div class="df-time-buttons" role="group" aria-label="Adjust session length">
-              <button type="button" data-action="time-less" aria-label="Choose a shorter session">Less</button>
-              <button type="button" data-action="time-more" aria-label="Add more session time">Add time</button>
-            </div>
-          </div>
-          <p class="df-hard-limit-note">
-            You have <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong>
-            left in today's limit for this network.
-          </p>
-          <div class="df-actions">
-            <button class="df-button df-button--quiet" data-action="leave">Leave</button>
-            <button class="df-button df-button--primary" data-action="continue" disabled>
-              ${
-                options.delaySeconds > 0
-                  ? `Continue in ${options.delaySeconds}s`
-                  : `Start ${defaultSessionLabel} session`
-              }
-            </button>
-          </div>
-          <button class="df-settings-link" data-action="settings">Adjust time and limits</button>
-        </article>
-      </section>
-    `;
+    this.overlay.replaceChildren(
+      createOpeningView({
+        platformLabel: options.platformLabel,
+        delaySeconds: options.delaySeconds,
+        defaultSessionLabel,
+        availableLabel: this.formatFriendlyDuration(options.availableSeconds),
+        usageMetrics: options.usageMetrics.map((metric) => ({
+          label: metric.label,
+          duration: this.formatUsageDuration(metric.usedSeconds),
+        })),
+      }),
+    );
 
     const countdown = this.overlay.querySelector<HTMLElement>(".df-countdown");
     const continueButton =
@@ -183,30 +148,13 @@ export class InterventionUi {
 
   showSessionEnded(options: SessionEndedOptions): Promise<number> {
     this.lockPage();
-    this.overlay.innerHTML = `
-      <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-session-end-title">
-        <article class="df-card">
-          <div class="df-rule"></div>
-          <p class="df-kicker">Planned time complete</p>
-          <h1 id="df-session-end-title">Your session has ended.</h1>
-          <p class="df-copy">
-            You chose to stop here. Leave now, or pause before deliberately planning more time.
-          </p>
-          <p class="df-hard-limit-note">
-            Your daily ceiling cannot be extended:
-            <strong>${this.formatFriendlyDuration(options.availableSeconds)}</strong> remaining.
-          </p>
-          <div class="df-actions">
-            <button class="df-button df-button--primary" data-action="leave">Leave ${options.platformLabel}</button>
-            <button class="df-button df-button--quiet" data-action="plan" disabled>
-              Plan another block in ${SESSION_REPLAN_DELAY_SECONDS}s
-            </button>
-          </div>
-          <p class="df-wait" aria-live="polite">Take a moment before deciding.</p>
-          <button class="df-settings-link" data-action="settings">Change the default</button>
-        </article>
-      </section>
-    `;
+    this.overlay.replaceChildren(
+      createSessionEndedView({
+        platformLabel: options.platformLabel,
+        availableLabel: this.formatFriendlyDuration(options.availableSeconds),
+        replanDelaySeconds: SESSION_REPLAN_DELAY_SECONDS,
+      }),
+    );
 
     const leaveButton =
       this.requiredElement<HTMLButtonElement>('[data-action="leave"]');
@@ -267,24 +215,12 @@ export class InterventionUi {
     const defaultSessionLabel =
       options.availableSeconds < 60 ? "<1 min" : `${defaultMinutes} min`;
     const card = this.requiredElement<HTMLElement>(".df-card");
-    card.innerHTML = `
-      <p class="df-kicker">Plan another block</p>
-      <h1>How much longer?</h1>
-      <p class="df-copy">Choose a defined block within today's remaining ceiling.</p>
-      <div class="df-time-choice df-time-stepper">
-        <span>New block</span>
-        <output aria-live="polite">${defaultSessionLabel}</output>
-        <div class="df-time-buttons" role="group" aria-label="Adjust new block length">
-          <button type="button" data-action="time-less" aria-label="Choose a shorter block">Less</button>
-          <button type="button" data-action="time-more" aria-label="Add more time to the block">Add time</button>
-        </div>
-      </div>
-      <div class="df-actions">
-        <button class="df-button df-button--quiet" data-action="leave">Leave ${options.platformLabel}</button>
-        <button class="df-button df-button--primary" data-action="extend">Start ${defaultSessionLabel} block</button>
-      </div>
-      <button class="df-settings-link" data-action="settings">Change the default</button>
-    `;
+    card.replaceChildren(
+      createSessionPlanningView({
+        platformLabel: options.platformLabel,
+        defaultSessionLabel,
+      }),
+    );
 
     const extendButton =
       this.requiredElement<HTMLButtonElement>('[data-action="extend"]');
@@ -322,22 +258,7 @@ export class InterventionUi {
     this.cancelPendingInteraction = undefined;
     cancelPendingInteraction?.();
     this.lockPage();
-    this.overlay.innerHTML = `
-      <section class="df-backdrop" role="dialog" aria-modal="true" aria-labelledby="df-hard-limit-title">
-        <article class="df-card">
-          <div class="df-lock-mark" aria-hidden="true"></div>
-          <p class="df-kicker">Daily limit reached</p>
-          <h1 id="df-hard-limit-title">${platformLabel} ends here for today.</h1>
-          <p class="df-copy">
-            This limit cannot be unlocked. It will be available again tomorrow.
-          </p>
-          <div class="df-actions df-actions--stack">
-            <button class="df-button df-button--primary" data-action="leave">Leave ${platformLabel}</button>
-          </div>
-          <button class="df-settings-link" data-action="settings">View settings</button>
-        </article>
-      </section>
-    `;
+    this.overlay.replaceChildren(createHardLimitView(platformLabel));
 
     this.requiredElement<HTMLButtonElement>('[data-action="leave"]')
       .addEventListener("click", () => this.leaveFeed());
@@ -347,15 +268,7 @@ export class InterventionUi {
 
   showUsageTimer(options: UsageTimerOptions): void {
     if (this.timer.childElementCount === 0) {
-      this.timer.innerHTML = `
-        <button class="df-usage-timer" type="button" title="Open Dopamine Fast settings">
-          <span class="df-usage-timer__pulse" aria-hidden="true"></span>
-          <span class="df-usage-timer__copy">
-            <strong data-timer="planned"></strong>
-            <small><span data-timer="platform"></span> · <span data-timer="daily"></span> today</small>
-          </span>
-        </button>
-      `;
+      this.timer.replaceChildren(createUsageTimerView());
       this.timer
         .querySelector<HTMLButtonElement>(".df-usage-timer")
         ?.addEventListener("click", () => this.openOptions());

--- a/lib/intervention-views.ts
+++ b/lib/intervention-views.ts
@@ -1,0 +1,367 @@
+interface OpeningViewOptions {
+  platformLabel: string;
+  delaySeconds: number;
+  defaultSessionLabel: string;
+  availableLabel: string;
+  usageMetrics: Array<{ label: string; duration: string }>;
+}
+
+interface SessionEndedViewOptions {
+  platformLabel: string;
+  availableLabel: string;
+  replanDelaySeconds: number;
+}
+
+interface SessionPlanningViewOptions {
+  platformLabel: string;
+  defaultSessionLabel: string;
+}
+
+interface ElementOptions {
+  className?: string;
+  text?: string;
+  attributes?: Record<string, string>;
+  children?: Node[];
+}
+
+export function createOpeningView(options: OpeningViewOptions): HTMLElement {
+  const pauseIndicator =
+    options.delaySeconds > 0
+      ? element("div", {
+          className: "df-countdown",
+          text: String(options.delaySeconds),
+          attributes: { "aria-live": "polite" },
+        })
+      : element("div", {
+          className: "df-pause-mark df-pause-mark--centered",
+          attributes: { "aria-hidden": "true" },
+        });
+  const usageItems = options.usageMetrics.map((metric) =>
+    element("div", {
+      className: "df-usage-summary__item",
+      children: [
+        element("span", { text: metric.label }),
+        element("strong", { text: metric.duration }),
+      ],
+    }),
+  );
+
+  return dialog(
+    "df-opening-title",
+    element("article", {
+      className: "df-card df-card--opening",
+      children: [
+        element("p", {
+          className: "df-kicker",
+          text: "A pause before entering",
+        }),
+        pauseIndicator,
+        element("h1", {
+          text: `How much time do you want to spend on ${options.platformLabel}?`,
+          attributes: { id: "df-opening-title" },
+        }),
+        element("p", {
+          className: "df-copy",
+          text: "Choose a defined session now. The timer will remain visible as you browse.",
+        }),
+        element("section", {
+          className: "df-usage-summary",
+          attributes: { "aria-labelledby": "df-usage-summary-title" },
+          children: [
+            element("p", {
+              text: "Time spent today",
+              attributes: { id: "df-usage-summary-title" },
+            }),
+            element("div", {
+              className: "df-usage-summary__items",
+              children: usageItems,
+            }),
+          ],
+        }),
+        timeStepper(
+          "This session",
+          options.defaultSessionLabel,
+          "Adjust session length",
+          "Choose a shorter session",
+          "Add more session time",
+        ),
+        element("p", {
+          className: "df-hard-limit-note",
+          children: [
+            document.createTextNode("You have "),
+            element("strong", { text: options.availableLabel }),
+            document.createTextNode(
+              " left in today's limit for this network.",
+            ),
+          ],
+        }),
+        element("div", {
+          className: "df-actions",
+          children: [
+            actionButton("Leave", "leave", "df-button df-button--quiet"),
+            actionButton(
+              options.delaySeconds > 0
+                ? `Continue in ${options.delaySeconds}s`
+                : `Start ${options.defaultSessionLabel} session`,
+              "continue",
+              "df-button df-button--primary",
+              true,
+            ),
+          ],
+        }),
+        actionButton(
+          "Adjust time and limits",
+          "settings",
+          "df-settings-link",
+        ),
+      ],
+    }),
+  );
+}
+
+export function createSessionEndedView(
+  options: SessionEndedViewOptions,
+): HTMLElement {
+  return dialog(
+    "df-session-end-title",
+    element("article", {
+      className: "df-card",
+      children: [
+        element("div", { className: "df-rule" }),
+        element("p", {
+          className: "df-kicker",
+          text: "Planned time complete",
+        }),
+        element("h1", {
+          text: "Your session has ended.",
+          attributes: { id: "df-session-end-title" },
+        }),
+        element("p", {
+          className: "df-copy",
+          text: "You chose to stop here. Leave now, or pause before deliberately planning more time.",
+        }),
+        element("p", {
+          className: "df-hard-limit-note",
+          children: [
+            document.createTextNode("Your daily ceiling cannot be extended: "),
+            element("strong", { text: options.availableLabel }),
+            document.createTextNode(" remaining."),
+          ],
+        }),
+        element("div", {
+          className: "df-actions",
+          children: [
+            actionButton(
+              `Leave ${options.platformLabel}`,
+              "leave",
+              "df-button df-button--primary",
+            ),
+            actionButton(
+              `Plan another block in ${options.replanDelaySeconds}s`,
+              "plan",
+              "df-button df-button--quiet",
+              true,
+            ),
+          ],
+        }),
+        element("p", {
+          className: "df-wait",
+          text: "Take a moment before deciding.",
+          attributes: { "aria-live": "polite" },
+        }),
+        actionButton(
+          "Change the default",
+          "settings",
+          "df-settings-link",
+        ),
+      ],
+    }),
+  );
+}
+
+export function createSessionPlanningView(
+  options: SessionPlanningViewOptions,
+): DocumentFragment {
+  const fragment = document.createDocumentFragment();
+  fragment.append(
+    element("p", { className: "df-kicker", text: "Plan another block" }),
+    element("h1", { text: "How much longer?" }),
+    element("p", {
+      className: "df-copy",
+      text: "Choose a defined block within today's remaining ceiling.",
+    }),
+    timeStepper(
+      "New block",
+      options.defaultSessionLabel,
+      "Adjust new block length",
+      "Choose a shorter block",
+      "Add more time to the block",
+    ),
+    element("div", {
+      className: "df-actions",
+      children: [
+        actionButton(
+          `Leave ${options.platformLabel}`,
+          "leave",
+          "df-button df-button--quiet",
+        ),
+        actionButton(
+          `Start ${options.defaultSessionLabel} block`,
+          "extend",
+          "df-button df-button--primary",
+        ),
+      ],
+    }),
+    actionButton(
+      "Change the default",
+      "settings",
+      "df-settings-link",
+    ),
+  );
+  return fragment;
+}
+
+export function createHardLimitView(platformLabel: string): HTMLElement {
+  return dialog(
+    "df-hard-limit-title",
+    element("article", {
+      className: "df-card",
+      children: [
+        element("div", {
+          className: "df-lock-mark",
+          attributes: { "aria-hidden": "true" },
+        }),
+        element("p", {
+          className: "df-kicker",
+          text: "Daily limit reached",
+        }),
+        element("h1", {
+          text: `${platformLabel} ends here for today.`,
+          attributes: { id: "df-hard-limit-title" },
+        }),
+        element("p", {
+          className: "df-copy",
+          text: "This limit cannot be unlocked. It will be available again tomorrow.",
+        }),
+        element("div", {
+          className: "df-actions df-actions--stack",
+          children: [
+            actionButton(
+              `Leave ${platformLabel}`,
+              "leave",
+              "df-button df-button--primary",
+            ),
+          ],
+        }),
+        actionButton("View settings", "settings", "df-settings-link"),
+      ],
+    }),
+  );
+}
+
+export function createUsageTimerView(): HTMLButtonElement {
+  return element("button", {
+    className: "df-usage-timer",
+    attributes: {
+      type: "button",
+      title: "Open Dopamine Fast settings",
+    },
+    children: [
+      element("span", {
+        className: "df-usage-timer__pulse",
+        attributes: { "aria-hidden": "true" },
+      }),
+      element("span", {
+        className: "df-usage-timer__copy",
+        children: [
+          element("strong", { attributes: { "data-timer": "planned" } }),
+          element("small", {
+            children: [
+              element("span", {
+                attributes: { "data-timer": "platform" },
+              }),
+              document.createTextNode(" · "),
+              element("span", {
+                attributes: { "data-timer": "daily" },
+              }),
+              document.createTextNode(" today"),
+            ],
+          }),
+        ],
+      }),
+    ],
+  });
+}
+
+function timeStepper(
+  label: string,
+  value: string,
+  groupLabel: string,
+  lessLabel: string,
+  moreLabel: string,
+): HTMLElement {
+  return element("div", {
+    className: "df-time-choice df-time-stepper",
+    children: [
+      element("span", { text: label }),
+      element("output", {
+        text: value,
+        attributes: { "aria-live": "polite" },
+      }),
+      element("div", {
+        className: "df-time-buttons",
+        attributes: { role: "group", "aria-label": groupLabel },
+        children: [
+          actionButton("Less", "time-less", undefined, false, lessLabel),
+          actionButton("Add time", "time-more", undefined, false, moreLabel),
+        ],
+      }),
+    ],
+  });
+}
+
+function dialog(labelledBy: string, card: HTMLElement): HTMLElement {
+  return element("section", {
+    className: "df-backdrop",
+    attributes: {
+      role: "dialog",
+      "aria-modal": "true",
+      "aria-labelledby": labelledBy,
+    },
+    children: [card],
+  });
+}
+
+function actionButton(
+  text: string,
+  action: string,
+  className?: string,
+  disabled = false,
+  ariaLabel?: string,
+): HTMLButtonElement {
+  const button = element("button", {
+    className,
+    text,
+    attributes: {
+      type: "button",
+      "data-action": action,
+      ...(ariaLabel ? { "aria-label": ariaLabel } : {}),
+    },
+  });
+  button.disabled = disabled;
+  return button;
+}
+
+function element<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
+  options: ElementOptions = {},
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tagName);
+  if (options.className) node.className = options.className;
+  if (options.text !== undefined) node.textContent = options.text;
+  Object.entries(options.attributes ?? {}).forEach(([name, value]) => {
+    node.setAttribute(name, value);
+  });
+  node.append(...(options.children ?? []));
+  return node;
+}


### PR DESCRIPTION
## What changed

- replace every intervention UI `innerHTML` assignment with explicit DOM construction
- move the screen builders into a focused `intervention-views.ts` module
- insert all dynamic labels and durations through `textContent`
- preserve the existing classes, accessibility attributes, actions, and timer behavior

## Why

Mozilla's add-on validator reported `Unsafe assignment to innerHTML`. The UI templates interpolated runtime labels into HTML strings, so the validator could not prove those assignments safe and the submission risked rejection.

## Impact

The rendered UI and extension permissions are unchanged. Removing HTML-string parsing eliminates the reported injection class and makes dynamic content safe by construction.

## Validation

- TypeScript strict check
- 11 Vitest files / 36 tests
- Firefox MV2 production build
- Mozilla `web-ext lint`: 0 errors, 0 notices
- confirmed the generated Firefox bundle contains no `innerHTML`

Mozilla still reports two unrelated compatibility warnings: the manifest supports Firefox 120 while `data_collection_permissions` was introduced in Firefox 140 and Firefox for Android 142. Resolving those warnings requires a separate minimum-version decision.
