### PR TITLE
feat(youtube): add intentional subscriptions feed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Supported networks:
 - Reddit
 - X/Twitter
 - Instagram
+- YouTube
 
 The extension operates on the authenticated web pages the user already visits.
 It does not use platform APIs, scrape in the background, read private messages,
@@ -131,6 +132,7 @@ lib/
   usage-history.ts       Pure normalization and retention for usage statistics
   preferred-feed.ts      Optional preferred-feed selection and tab restoration
   intentional-search.ts Search suggestion and discovery-surface suppression
+  surface-suppression.ts Reversible Shorts and recommendation suppression
   single-item-view.ts   Scroll lock for explicitly opened single-item surfaces
   intervention-ui.ts     Shadow-DOM overlays, timer and deliberate interactions
   runtime-messages.ts    Validated background/content message contracts
@@ -176,6 +178,8 @@ Specific responsibilities:
   browser or DOM dependencies.
 - `preferred-feed.ts` applies an adapter-defined preferred tab and restores any
   tab styles it changes during teardown.
+- `surface-suppression.ts` applies adapter-scoped navigation and recommendation
+  rules and restores every inline display style it changes during teardown.
 - `single-item-view.ts` blocks vertical feed navigation on an explicitly
   opened item and restores page styles and listeners during teardown.
 - `platforms.ts` is the only home for network-specific hosts, feed routes,

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -133,8 +133,8 @@ visible area while the batch is closed.
   video remains available without vertical Shorts navigation.
 - When the optional Subscriptions-only setting is enabled, redirect Home to
   `/feed/subscriptions` and hide Home navigation.
-- In Subscriptions-only mode, hide next-video, related-video, Shorts and
-  end-screen recommendation surfaces on requested video pages.
+- Always hide next-video, related-video, Shorts and end-screen recommendation
+  surfaces on requested video pages.
 - Treat YouTube post and time budgets independently from every other network.
 
 ## Privacy and permissions

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -7,7 +7,7 @@ Keep the useful parts of social networks while giving every feed a real end.
 ## Initial target
 
 - Firefox for Android
-- Reddit, X and Instagram mobile websites
+- Reddit, X, Instagram and YouTube mobile websites
 - English-language application interface
 - Authenticated browser sessions, including private content the user is already
   authorized to see
@@ -28,7 +28,7 @@ Keep the useful parts of social networks while giving every feed a real end.
 ## Time budgets
 
 - Before entry, the user selects an intentional session duration.
-- The opening screen shows today's elapsed time for Reddit, X and Instagram
+- The opening screen shows today's elapsed time for Reddit, X, Instagram and YouTube
   before another session is planned.
 - Session duration changes use discrete buttons instead of a slider, so adding
   more time requires a separate deliberate press for each step.
@@ -123,6 +123,19 @@ visible area while the batch is closed.
   blocking vertical wheel, keyboard and touch navigation to another reel.
 - Stop after the active batch or after Instagram's own caught-up marker,
   whichever comes first.
+
+### YouTube
+
+- Limit Home and the Subscriptions feed to the active finite batch while
+  leaving search, channels, comments and explicitly opened videos available.
+- Hide Shorts navigation and Shorts shelves. Convert an explicitly opened
+  `/shorts/{id}` route to the standard `/watch?v={id}` player so the requested
+  video remains available without vertical Shorts navigation.
+- When the optional Subscriptions-only setting is enabled, redirect Home to
+  `/feed/subscriptions` and hide Home navigation.
+- In Subscriptions-only mode, hide next-video, related-video, Shorts and
+  end-screen recommendation surfaces on requested video pages.
+- Treat YouTube post and time budgets independently from every other network.
 
 ## Privacy and permissions
 

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ of loading more posts automatically.
 - YouTube Shorts surfaces are hidden, and directly opened Shorts use the
   standard video player instead of the vertical Shorts feed.
 - Optional YouTube Subscriptions-only mode redirects Home to Subscriptions and
-  hides Home plus next-video and recommendation surfaces around requested
-  videos.
+  hides Home. Next-video and recommendation surfaces around requested videos
+  are always hidden.
 - Non-extendable daily time ceiling for each network.
 - Finite initial and additional post batches.
 - Stable per-session post counting for virtualized feeds such as Reddit.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The extension works on top of the authenticated websites you already use. It
 does not build a new feed, copy posts, use platform APIs, inspect private
 messages, or send browsing data to a backend.
 
-> **Project status:** early prototype. Reddit, X/Twitter, and Instagram are
+> **Project status:** early prototype. Reddit, X/Twitter, Instagram, and YouTube are
 > supported, but their interfaces change frequently and the selectors still
 > require regular testing on mobile and desktop.
 
@@ -29,7 +29,7 @@ available while adding deliberate friction around habitual scrolling:
 7. A per-network daily time ceiling cannot be extended from the page.
 
 Daily post allowances and time ceilings are tracked independently for Reddit,
-X/Twitter, and Instagram.
+X/Twitter, Instagram, and YouTube.
 Preferences and aggregate counters stay in browser extension local storage.
 Elapsed seconds per network are retained for the 30 most recent days with
 activity; active session countdowns are not stored in that history.
@@ -57,6 +57,11 @@ of loading more posts automatically.
   News and Explore shortcuts are also hidden.
 - Instagram's Reels destination is hidden; a directly opened reel remains
   usable without vertical navigation into an endless sequence.
+- YouTube Shorts surfaces are hidden, and directly opened Shorts use the
+  standard video player instead of the vertical Shorts feed.
+- Optional YouTube Subscriptions-only mode redirects Home to Subscriptions and
+  hides Home plus next-video and recommendation surfaces around requested
+  videos.
 - Non-extendable daily time ceiling for each network.
 - Finite initial and additional post batches.
 - Stable per-session post counting for virtualized feeds such as Reddit.
@@ -74,6 +79,7 @@ of loading more posts automatically.
 | Reddit | Yes | Best effort | Independent |
 | X / Twitter | Yes | Best effort | Independent |
 | Instagram | Yes | Best effort | Independent |
+| YouTube | Yes | Best effort | Independent |
 
 The limiter applies only to recognized feed routes. Direct profiles, messages,
 settings, and individual post pages are intended to remain available. Platform
@@ -154,7 +160,7 @@ limitations, and contributor guidance.
 
 ## Privacy and security
 
-Dopamine Fast requests access only to Reddit, X/Twitter, and Instagram, plus
+Dopamine Fast requests access only to Reddit, X/Twitter, Instagram, and YouTube, plus
 the browser's local storage permission. It has:
 
 - no account system;

--- a/docs/YOUTUBE_ADAPTER_NOTES.md
+++ b/docs/YOUTUBE_ADAPTER_NOTES.md
@@ -60,8 +60,8 @@ children of `ytm-single-column-watch-next-results-renderer`:
 - two regular recommendation sections containing `/watch` links; and
 - one Shorts recommendation section containing 15 `/shorts/` links.
 
-Subscriptions-only mode hides only those direct recommendation sections.
-The player, title, channel controls, actions and comments remain available.
+Dopamine Fast always hides only those direct recommendation sections. The
+player, title, channel controls, actions and comments remain available.
 
 ## Known limitations
 

--- a/docs/YOUTUBE_ADAPTER_NOTES.md
+++ b/docs/YOUTUBE_ADAPTER_NOTES.md
@@ -1,0 +1,85 @@
+# YouTube adapter notes
+
+This document records authenticated DOM observations used by the YouTube
+adapter. YouTube serves substantially different desktop and responsive/mobile
+renderers, so every selector remains scoped to a named platform component.
+
+## Verified environment
+
+- Date: 2026-08-05
+- Browser: authenticated Chrome desktop session on Windows
+- Page language: Spanish
+- Responsive viewport: 391 by 844 CSS pixels
+- Pages: `/`, `/feed/subscriptions`, `/results?search_query={query}`, and
+  `/watch?v={id}`
+
+The verified layout used YouTube's responsive `ytm-*` renderers. The adapter
+also includes narrow `ytd-*` equivalents for desktop, but a wide desktop and
+Firefox Android smoke test remain required before release.
+
+## Navigation and routes
+
+The bottom navigation exposed `Inicio`, `Shorts`, and `Suscripciones` as exact
+`[role="tab"]` labels inside `ytm-pivot-bar-item-renderer`. Subscriptions used
+`aria-selected="true"` at `/feed/subscriptions`.
+
+Short links used `/shorts/{id}`. Dopamine Fast hides the exact Shorts
+navigation item and converts a directly requested Short to `/watch?v={id}`.
+This preserves the requested video in YouTube's standard player without
+opening the vertical Shorts feed.
+
+## Feed items and Shorts shelves
+
+On the responsive Home and Subscriptions feeds, regular cards used
+`ytm-rich-item-renderer`. A regular subscription video nested its `/watch`
+link inside `ytm-video-with-context-renderer` and `ytm-rich-item-renderer`.
+Stable post identity comes from the `v` query parameter rather than visible
+text.
+
+The inspected Subscriptions route rendered:
+
+- 8 current `ytm-rich-item-renderer` feed items;
+- 15 `/shorts/{id}` links inside one `ytm-rich-section-renderer` and
+  `ytm-reel-shelf-renderer`; and
+- 24 current `/watch` links as YouTube continued populating the feed.
+
+The inspected search route rendered 16 `/shorts/{id}` links inside a
+`grid-shelf-view-model`. The same scoped shelf rule therefore removes Shorts
+from user-requested search results without hiding regular results.
+
+Shorts are suppressed by locating a `/shorts/` anchor and walking only to a
+known Shorts shelf or item renderer. The rule never hides an arbitrary broad
+parent when no known container exists.
+
+## Watch recommendations
+
+On the inspected watch route, comments occupied an `ytm-item-section-renderer`
+whose parent was a regular `div`. Recommendation groups were separate direct
+children of `ytm-single-column-watch-next-results-renderer`:
+
+- two regular recommendation sections containing `/watch` links; and
+- one Shorts recommendation section containing 15 `/shorts/` links.
+
+Subscriptions-only mode hides only those direct recommendation sections.
+The player, title, channel controls, actions and comments remain available.
+
+## Known limitations
+
+- Suppression is presentation-layer only; YouTube may still prefetch hidden
+  recommendations or Shorts.
+- Desktop `ytd-*` selectors are narrow fallbacks but were not visually verified
+  in this responsive inspection.
+- YouTube frequently replaces renderer families and requires signed-in mobile
+  and desktop verification after selector changes.
+
+## Manual verification checklist
+
+1. Confirm Shorts is absent from the responsive and desktop navigation.
+2. Confirm Shorts shelves are absent from Home, Subscriptions and watch pages.
+3. Open a direct `/shorts/{id}` URL and confirm it becomes `/watch?v={id}`.
+4. Enable Subscriptions only and open `/`; confirm navigation reaches
+   `/feed/subscriptions` and Home is hidden.
+5. Open a normal video and confirm recommendations and next-video surfaces are
+   absent while comments and playback controls still work.
+6. Start a feed session and verify the finite batch counts regular subscription
+   items without counting the removed Shorts shelf.

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -6,6 +6,7 @@ import { availableUsageSeconds, localDateKey } from "../lib/models";
 import { getPlatformAdapter } from "../lib/platforms";
 import { PreferredFeedController } from "../lib/preferred-feed";
 import { SingleItemViewController } from "../lib/single-item-view";
+import { SurfaceSuppressionController } from "../lib/surface-suppression";
 import {
   getDailyUsageState,
   getSettings,
@@ -25,6 +26,9 @@ export default defineContentScript({
     "*://twitter.com/*",
     "*://www.instagram.com/*",
     "*://instagram.com/*",
+    "*://www.youtube.com/*",
+    "*://m.youtube.com/*",
+    "*://youtube.com/*",
   ],
   runAt: "document_start",
   cssInjectionMode: "ui",
@@ -66,6 +70,7 @@ export default defineContentScript({
     let intentionalSearch: IntentionalSearchController | undefined;
     let preferredFeed: PreferredFeedController | undefined;
     let singleItemView: SingleItemViewController | undefined;
+    let surfaceSuppression: SurfaceSuppressionController | undefined;
     let usageSession: UsageSession | undefined;
     let currentUrl = "";
     let activationId = 0;
@@ -80,6 +85,8 @@ export default defineContentScript({
       preferredFeed = undefined;
       singleItemView?.destroy();
       singleItemView = undefined;
+      surfaceSuppression?.destroy();
+      surfaceSuppression = undefined;
       const previousUsageSession = usageSession;
       usageSession = undefined;
       await previousUsageSession?.destroy();
@@ -91,6 +98,30 @@ export default defineContentScript({
       if (thisActivation !== activationId) return;
       if (!settings.enabled || !settings.enabledSites[adapter.id]) {
         return;
+      }
+
+      const surfaceConfig = adapter.surfaceSuppression;
+      const subscriptionsOnly =
+        adapter.id === "youtube" && settings.youtubeSubscriptionsOnly;
+      const canonicalUrl = surfaceConfig?.canonicalUrl(url);
+      if (canonicalUrl && canonicalUrl.href !== url.href) {
+        location.replace(canonicalUrl.href);
+        return;
+      }
+      if (
+        subscriptionsOnly &&
+        surfaceConfig &&
+        url.pathname === "/"
+      ) {
+        location.replace(new URL(surfaceConfig.subscriptionsPath, url).href);
+        return;
+      }
+      if (surfaceConfig) {
+        surfaceSuppression = new SurfaceSuppressionController(
+          adapter,
+          subscriptionsOnly,
+        );
+        surfaceSuppression.start();
       }
 
       if (
@@ -147,6 +178,7 @@ export default defineContentScript({
           { label: "Reddit", usedSeconds: todayUsage.reddit },
           { label: "X", usedSeconds: todayUsage.x },
           { label: "Instagram", usedSeconds: todayUsage.instagram },
+          { label: "YouTube", usedSeconds: todayUsage.youtube },
         ],
       });
       if (thisActivation !== activationId) return;
@@ -247,6 +279,7 @@ export default defineContentScript({
       intentionalSearch?.destroy();
       preferredFeed?.destroy();
       singleItemView?.destroy();
+      surfaceSuppression?.destroy();
       void usageSession?.destroy();
       shadowUi.remove();
     });

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -210,6 +210,8 @@
             <label><span>X: Following only</span><input id="x-following-only" type="checkbox" /></label>
             <label><span>Instagram</span><input id="site-instagram" type="checkbox" /></label>
             <label><span>Instagram: Following only</span><input id="instagram-following-only" type="checkbox" /></label>
+            <label><span>YouTube</span><input id="site-youtube" type="checkbox" /></label>
+            <label><span>YouTube: Subscriptions only</span><input id="youtube-subscriptions-only" type="checkbox" /></label>
             <label><span>Hide suggestions</span><input id="block-suggested" type="checkbox" /></label>
             <label><span>Stop autoplay</span><input id="disable-autoplay" type="checkbox" /></label>
           </div>

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -38,6 +38,10 @@ const controls = {
   instagramFollowingOnly: requiredElement<HTMLInputElement>(
     "#instagram-following-only",
   ),
+  youtube: requiredElement<HTMLInputElement>("#site-youtube"),
+  youtubeSubscriptionsOnly: requiredElement<HTMLInputElement>(
+    "#youtube-subscriptions-only",
+  ),
   blockSuggested: requiredElement<HTMLInputElement>("#block-suggested"),
   disableAutoplay: requiredElement<HTMLInputElement>("#disable-autoplay"),
 };
@@ -69,6 +73,8 @@ function render(settings: Settings): void {
   controls.xFollowingOnly.checked = settings.xFollowingOnly;
   controls.instagram.checked = settings.enabledSites.instagram;
   controls.instagramFollowingOnly.checked = settings.instagramFollowingOnly;
+  controls.youtube.checked = settings.enabledSites.youtube;
+  controls.youtubeSubscriptionsOnly.checked = settings.youtubeSubscriptionsOnly;
   controls.blockSuggested.checked = settings.blockSuggested;
   controls.disableAutoplay.checked = settings.disableAutoplay;
   requiredElement<HTMLInputElement>(
@@ -97,10 +103,12 @@ function readSettings(): Settings {
     disableAutoplay: controls.disableAutoplay.checked,
     xFollowingOnly: controls.xFollowingOnly.checked,
     instagramFollowingOnly: controls.instagramFollowingOnly.checked,
+    youtubeSubscriptionsOnly: controls.youtubeSubscriptionsOnly.checked,
     enabledSites: {
       reddit: controls.reddit.checked,
       x: controls.x.checked,
       instagram: controls.instagram.checked,
+      youtube: controls.youtube.checked,
     },
   });
 }
@@ -120,6 +128,14 @@ controls.xFollowingOnly.addEventListener("change", async () => {
 controls.instagramFollowingOnly.addEventListener("change", async () => {
   await saveSettings(readSettings());
   status.textContent = "Instagram feed preference applied.";
+  window.setTimeout(() => {
+    status.textContent = "";
+  }, 2400);
+});
+
+controls.youtubeSubscriptionsOnly.addEventListener("change", async () => {
+  await saveSettings(readSettings());
+  status.textContent = "YouTube feed preference applied.";
   window.setTimeout(() => {
     status.textContent = "";
   }, 2400);

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,4 +1,4 @@
-export type PlatformId = "reddit" | "x" | "instagram";
+export type PlatformId = "reddit" | "x" | "instagram" | "youtube";
 export type GuardMode = "gentle" | "balanced" | "strict";
 
 export interface Settings {
@@ -16,6 +16,7 @@ export interface Settings {
   disableAutoplay: boolean;
   xFollowingOnly: boolean;
   instagramFollowingOnly: boolean;
+  youtubeSubscriptionsOnly: boolean;
   enabledSites: Record<PlatformId, boolean>;
 }
 
@@ -48,10 +49,12 @@ export const DEFAULT_SETTINGS: Settings = {
   disableAutoplay: true,
   xFollowingOnly: false,
   instagramFollowingOnly: false,
+  youtubeSubscriptionsOnly: false,
   enabledSites: {
     reddit: true,
     x: true,
     instagram: true,
+    youtube: true,
   },
 };
 
@@ -116,9 +119,27 @@ export function sanitizeSettings(input: Partial<Settings>): Settings {
       typeof input.instagramFollowingOnly === "boolean"
         ? input.instagramFollowingOnly
         : DEFAULT_SETTINGS.instagramFollowingOnly,
+    youtubeSubscriptionsOnly:
+      typeof input.youtubeSubscriptionsOnly === "boolean"
+        ? input.youtubeSubscriptionsOnly
+        : DEFAULT_SETTINGS.youtubeSubscriptionsOnly,
     enabledSites: {
-      ...DEFAULT_SETTINGS.enabledSites,
-      ...input.enabledSites,
+      reddit: sanitizeBoolean(
+        input.enabledSites?.reddit,
+        DEFAULT_SETTINGS.enabledSites.reddit,
+      ),
+      x: sanitizeBoolean(
+        input.enabledSites?.x,
+        DEFAULT_SETTINGS.enabledSites.x,
+      ),
+      instagram: sanitizeBoolean(
+        input.enabledSites?.instagram,
+        DEFAULT_SETTINGS.enabledSites.instagram,
+      ),
+      youtube: sanitizeBoolean(
+        input.enabledSites?.youtube,
+        DEFAULT_SETTINGS.enabledSites.youtube,
+      ),
     },
   };
 }
@@ -138,12 +159,14 @@ export function emptyDailyState(date = new Date()): DailyState {
       reddit: 0,
       x: 0,
       instagram: 0,
+      youtube: 0,
     },
     unlocks: 0,
     unlocksByPlatform: {
       reddit: 0,
       x: 0,
       instagram: 0,
+      youtube: 0,
     },
   };
 }
@@ -176,12 +199,17 @@ export function emptyDailyUsageState(
       reddit: 0,
       x: 0,
       instagram: 0,
+      youtube: 0,
     },
   };
 }
 
 export function normalizeDailyUsageState(
-  state: DailyUsageState | null,
+  state:
+    | (Partial<Omit<DailyUsageState, "usedSecondsByPlatform">> & {
+        usedSecondsByPlatform?: Partial<Record<PlatformId, number>>;
+      })
+    | null,
   date = new Date(),
   configuredLimitMinutes = DEFAULT_SETTINGS.dailyUsageLimitMinutes,
 ): DailyUsageState {
@@ -189,10 +217,16 @@ export function normalizeDailyUsageState(
     return emptyDailyUsageState(date, configuredLimitMinutes);
   }
 
-  if (state.dailyLimitMinutes >= 5) return state;
   return {
-    ...state,
-    dailyLimitMinutes: configuredLimitMinutes,
+    date: state.date,
+    dailyLimitMinutes:
+      typeof state.dailyLimitMinutes === "number" &&
+      state.dailyLimitMinutes >= 5
+        ? state.dailyLimitMinutes
+        : configuredLimitMinutes,
+    usedSecondsByPlatform: normalizePlatformCounts(
+      state.usedSecondsByPlatform,
+    ),
   };
 }
 
@@ -230,6 +264,7 @@ function normalizePlatformCounts(
     reddit: normalizeCount(counts?.reddit),
     x: normalizeCount(counts?.x),
     instagram: normalizeCount(counts?.instagram),
+    youtube: normalizeCount(counts?.youtube),
   };
 }
 
@@ -238,5 +273,9 @@ function normalizeCount(value: number | undefined): number {
 }
 
 function sumPlatformCounts(counts: Record<PlatformId, number>): number {
-  return counts.reddit + counts.x + counts.instagram;
+  return counts.reddit + counts.x + counts.instagram + counts.youtube;
+}
+
+function sanitizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
 }

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -32,8 +32,20 @@ export interface PlatformAdapter {
     itemRootSelector: string;
     navigationSelectors: string[];
   };
+  surfaceSuppression?: {
+    always: SurfaceSuppressionRule[];
+    subscriptionsOnly: SurfaceSuppressionRule[];
+    subscriptionsPath: string;
+    canonicalUrl(url: URL): URL | undefined;
+  };
   getPostKey(element: HTMLElement): string | undefined;
   isFeedRoute(url: URL): boolean;
+}
+
+export interface SurfaceSuppressionRule {
+  selector: string;
+  exactTokens?: string[];
+  ancestorSelectors?: string[];
 }
 
 const reddit: PlatformAdapter = {
@@ -237,7 +249,99 @@ const instagram: PlatformAdapter = {
   },
 };
 
-const adapters = [reddit, x, instagram];
+const youtube: PlatformAdapter = {
+  id: "youtube",
+  label: "YouTube",
+  postSelectors: [
+    "ytd-rich-item-renderer",
+    "ytm-rich-item-renderer",
+    "ytd-grid-video-renderer",
+  ],
+  suggestedSelectors: [
+    "ytd-promoted-sparkles-web-renderer",
+    "ytm-promoted-sparkles-web-renderer",
+    "ytd-ad-slot-renderer",
+    "ytm-ad-slot-renderer",
+  ],
+  suggestedTokens: ["promoted", "sponsored", "promocionado", "patrocinado"],
+  surfaceSuppression: {
+    subscriptionsPath: "/feed/subscriptions",
+    canonicalUrl(url) {
+      const match = /^\/shorts\/([^/]+)\/?$/.exec(url.pathname);
+      if (!match?.[1]) return undefined;
+      const canonical = new URL("/watch", url.origin);
+      canonical.searchParams.set("v", match[1]);
+      return canonical;
+    },
+    always: [
+      {
+        selector: 'a[href="/shorts"], a[href="/shorts/"]',
+        ancestorSelectors: [
+          "ytd-guide-entry-renderer",
+          "ytd-mini-guide-entry-renderer",
+          "ytm-pivot-bar-item-renderer",
+        ],
+      },
+      {
+        selector: "ytm-pivot-bar-item-renderer [role=\"tab\"]",
+        exactTokens: ["shorts"],
+        ancestorSelectors: ["ytm-pivot-bar-item-renderer"],
+      },
+      {
+        selector: 'a[href^="/shorts/"]',
+        ancestorSelectors: [
+          "ytm-rich-section-renderer",
+          "ytd-rich-section-renderer",
+          "grid-shelf-view-model",
+          "ytm-item-section-renderer",
+          "ytm-reel-shelf-renderer",
+          "ytd-reel-shelf-renderer",
+          "ytm-shorts-lockup-view-model",
+          "ytd-reel-item-renderer",
+        ],
+      },
+      { selector: "ytm-reel-shelf-renderer, ytd-reel-shelf-renderer" },
+    ],
+    subscriptionsOnly: [
+      {
+        selector:
+          'ytd-guide-entry-renderer a[href="/"], ytd-mini-guide-entry-renderer a[href="/"]',
+        ancestorSelectors: [
+          "ytd-guide-entry-renderer",
+          "ytd-mini-guide-entry-renderer",
+        ],
+      },
+      {
+        selector: "ytm-pivot-bar-item-renderer [role=\"tab\"]",
+        exactTokens: ["home", "inicio"],
+        ancestorSelectors: ["ytm-pivot-bar-item-renderer"],
+      },
+      {
+        selector:
+          "#related, ytd-watch-next-secondary-results-renderer, ytm-single-column-watch-next-results-renderer > ytm-item-section-renderer",
+      },
+      {
+        selector:
+          ".ytp-autonav-endscreen-upnext-container, .ytp-endscreen-content",
+      },
+    ],
+  },
+  getPostKey(element) {
+    const href = element
+      .querySelector<HTMLAnchorElement>('a[href^="/watch"]')
+      ?.getAttribute("href");
+    if (!href) return undefined;
+    const videoId = new URL(href, "https://www.youtube.com").searchParams.get(
+      "v",
+    );
+    return videoId ? `video:${videoId}` : undefined;
+  },
+  isFeedRoute(url) {
+    return url.pathname === "/" || url.pathname === "/feed/subscriptions";
+  },
+};
+
+const adapters = [reddit, x, instagram, youtube];
 
 export function getPlatformAdapter(
   hostname: string,
@@ -246,6 +350,9 @@ export function getPlatformAdapter(
   if (normalized === "reddit.com") return reddit;
   if (normalized === "x.com" || normalized === "twitter.com") return x;
   if (normalized === "instagram.com") return instagram;
+  if (normalized === "youtube.com" || normalized === "m.youtube.com") {
+    return youtube;
+  }
   return undefined;
 }
 

--- a/lib/platforms.ts
+++ b/lib/platforms.ts
@@ -301,6 +301,14 @@ const youtube: PlatformAdapter = {
         ],
       },
       { selector: "ytm-reel-shelf-renderer, ytd-reel-shelf-renderer" },
+      {
+        selector:
+          "#related, ytd-watch-next-secondary-results-renderer, ytm-single-column-watch-next-results-renderer > ytm-item-section-renderer",
+      },
+      {
+        selector:
+          ".ytp-autonav-endscreen-upnext-container, .ytp-endscreen-content",
+      },
     ],
     subscriptionsOnly: [
       {
@@ -315,14 +323,6 @@ const youtube: PlatformAdapter = {
         selector: "ytm-pivot-bar-item-renderer [role=\"tab\"]",
         exactTokens: ["home", "inicio"],
         ancestorSelectors: ["ytm-pivot-bar-item-renderer"],
-      },
-      {
-        selector:
-          "#related, ytd-watch-next-secondary-results-renderer, ytm-single-column-watch-next-results-renderer > ytm-item-section-renderer",
-      },
-      {
-        selector:
-          ".ytp-autonav-endscreen-upnext-container, .ytp-endscreen-content",
       },
     ],
   },

--- a/lib/runtime-messages.ts
+++ b/lib/runtime-messages.ts
@@ -49,7 +49,10 @@ export function isRuntimeMessage(value: unknown): value is RuntimeMessage {
 }
 
 const isPlatform = (value: unknown): value is PlatformId =>
-  value === "reddit" || value === "x" || value === "instagram";
+  value === "reddit" ||
+  value === "x" ||
+  value === "instagram" ||
+  value === "youtube";
 
 const isFiniteNumber = (value: unknown): value is number =>
   typeof value === "number" && Number.isFinite(value);

--- a/lib/surface-suppression.ts
+++ b/lib/surface-suppression.ts
@@ -1,0 +1,98 @@
+import type {
+  PlatformAdapter,
+  SurfaceSuppressionRule,
+} from "./platforms";
+
+interface OriginalDisplay {
+  value: string;
+  priority: string;
+}
+
+export class SurfaceSuppressionController {
+  private readonly hidden = new Map<HTMLElement, OriginalDisplay>();
+  private readonly observer: MutationObserver;
+  private processingTimer?: number;
+  private destroyed = false;
+
+  constructor(
+    private readonly adapter: PlatformAdapter,
+    private readonly subscriptionsOnly: boolean,
+  ) {
+    this.observer = new MutationObserver(() => this.scheduleProcess());
+  }
+
+  start(): void {
+    if (!this.adapter.surfaceSuppression) return;
+    this.process();
+    this.observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["href", "aria-label"],
+    });
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.observer.disconnect();
+    if (this.processingTimer) window.clearTimeout(this.processingTimer);
+    this.hidden.forEach((display, element) => {
+      element.style.setProperty("display", display.value, display.priority);
+      delete element.dataset.dopamineFastHiddenSurface;
+    });
+    this.hidden.clear();
+  }
+
+  private scheduleProcess(): void {
+    if (this.destroyed || this.processingTimer) return;
+    this.processingTimer = window.setTimeout(() => {
+      this.processingTimer = undefined;
+      this.process();
+    }, 80);
+  }
+
+  private process(): void {
+    const config = this.adapter.surfaceSuppression;
+    if (!config || this.destroyed) return;
+    const rules = this.subscriptionsOnly
+      ? [...config.always, ...config.subscriptionsOnly]
+      : config.always;
+    rules.forEach((rule) => this.applyRule(rule));
+  }
+
+  private applyRule(rule: SurfaceSuppressionRule): void {
+    document.querySelectorAll<HTMLElement>(rule.selector).forEach((element) => {
+      if (
+        rule.exactTokens &&
+        !matchesExactToken(element.textContent, rule.exactTokens)
+      ) {
+        return;
+      }
+      const target =
+        rule.ancestorSelectors
+          ?.map((selector) => element.closest<HTMLElement>(selector))
+          .find((candidate): candidate is HTMLElement => candidate !== null) ??
+        element;
+      this.hide(target);
+    });
+  }
+
+  private hide(element: HTMLElement): void {
+    if (!this.hidden.has(element)) {
+      this.hidden.set(element, {
+        value: element.style.getPropertyValue("display"),
+        priority: element.style.getPropertyPriority("display"),
+      });
+    }
+    element.dataset.dopamineFastHiddenSurface = "true";
+    element.style.setProperty("display", "none", "important");
+  }
+}
+
+export function matchesExactToken(
+  label: string | null,
+  tokens: string[],
+): boolean {
+  const normalized = label?.trim().toLocaleLowerCase() ?? "";
+  return tokens.some((token) => normalized === token);
+}

--- a/lib/usage-history.ts
+++ b/lib/usage-history.ts
@@ -11,7 +11,7 @@ export interface UsageHistory {
   days: UsageHistoryDay[];
 }
 
-const PLATFORM_IDS: PlatformId[] = ["reddit", "x", "instagram"];
+const PLATFORM_IDS: PlatformId[] = ["reddit", "x", "instagram", "youtube"];
 const MAX_DAILY_SECONDS = 24 * 60 * 60;
 
 export function emptyUsageHistory(): UsageHistory {
@@ -59,6 +59,10 @@ export function recordUsageState(
           instagram: Math.max(
             previous.usedSecondsByPlatform.instagram,
             day.usedSecondsByPlatform.instagram,
+          ),
+          youtube: Math.max(
+            previous.usedSecondsByPlatform.youtube,
+            day.usedSecondsByPlatform.youtube,
           ),
         },
       }
@@ -114,7 +118,7 @@ function normalizeDay(value: unknown): UsageHistoryDay | undefined {
 }
 
 function emptyPlatformUsage(): Record<PlatformId, number> {
-  return { reddit: 0, x: 0, instagram: 0 };
+  return { reddit: 0, x: 0, instagram: 0, youtube: 0 };
 }
 
 function normalizeSeconds(value: unknown): number {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dopamine-fast",
   "version": "0.3.1",
-  "description": "A finite-feed guardrail for Reddit, X and Instagram.",
+  "description": "A finite-feed guardrail for Reddit, X, Instagram and YouTube.",
   "license": "MIT",
   "private": true,
   "type": "module",

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -23,6 +23,11 @@ describe("settings", () => {
       holdSeconds: 0,
       xFollowingOnly: "yes" as unknown as boolean,
       instagramFollowingOnly: "yes" as unknown as boolean,
+      youtubeSubscriptionsOnly: "yes" as unknown as boolean,
+      enabledSites: {
+        ...DEFAULT_SETTINGS.enabledSites,
+        youtube: "yes" as unknown as boolean,
+      },
     });
 
     expect(settings.openingDelaySeconds).toBe(60);
@@ -34,6 +39,7 @@ describe("settings", () => {
     expect(settings.holdSeconds).toBe(1);
     expect(settings.xFollowingOnly).toBe(false);
     expect(settings.instagramFollowingOnly).toBe(false);
+    expect(settings.youtubeSubscriptionsOnly).toBe(false);
     expect(settings.enabledSites).toEqual(DEFAULT_SETTINGS.enabledSites);
   });
 
@@ -48,6 +54,16 @@ describe("settings", () => {
       sanitizeSettings({ instagramFollowingOnly: true })
         .instagramFollowingOnly,
     ).toBe(true);
+  });
+
+  it("keeps an explicit YouTube subscriptions preference", () => {
+    const settings = sanitizeSettings({
+      youtubeSubscriptionsOnly: true,
+      enabledSites: { ...DEFAULT_SETTINGS.enabledSites, youtube: false },
+    });
+
+    expect(settings.youtubeSubscriptionsOnly).toBe(true);
+    expect(settings.enabledSites.youtube).toBe(false);
   });
 });
 
@@ -75,6 +91,7 @@ describe("daily state", () => {
         reddit: 35,
         x: 10,
         instagram: 0,
+        youtube: 0,
       },
     };
     expect(
@@ -97,14 +114,14 @@ describe("daily state", () => {
     const legacy = {
       date: localDateKey(today),
       revealed: 30,
-      revealedByPlatform: { reddit: 20, x: 10, instagram: 0 },
+      revealedByPlatform: { reddit: 20, x: 10, instagram: 0, youtube: 0 },
       unlocks: 2,
     };
 
     expect(normalizeDailyState(legacy, today)).toEqual({
       ...legacy,
       unlocks: 0,
-      unlocksByPlatform: { reddit: 0, x: 0, instagram: 0 },
+      unlocksByPlatform: { reddit: 0, x: 0, instagram: 0, youtube: 0 },
     });
   });
 
@@ -115,6 +132,7 @@ describe("daily state", () => {
         reddit: 900,
         x: 0,
         instagram: 0,
+        youtube: 0,
       },
     };
     const currentUsage = normalizeDailyUsageState(staleUsage, today, 10);
@@ -150,5 +168,21 @@ describe("daily state", () => {
         "reddit",
       ),
     ).toBe(1200);
+  });
+
+  it("adds safe YouTube counters to current-day legacy usage", () => {
+    const legacy = {
+      date: localDateKey(today),
+      dailyLimitMinutes: 30,
+      usedSecondsByPlatform: { reddit: 60, x: 0, instagram: 0 },
+    };
+
+    expect(normalizeDailyUsageState(legacy, today, 30)).toEqual({
+      ...legacy,
+      usedSecondsByPlatform: {
+        ...legacy.usedSecondsByPlatform,
+        youtube: 0,
+      },
+    });
   });
 });

--- a/tests/platforms.test.ts
+++ b/tests/platforms.test.ts
@@ -112,10 +112,15 @@ describe("platform adapters", () => {
       true,
     );
     expect(
-      config.subscriptionsOnly.some((rule) =>
+      config.always.some((rule) =>
         rule.selector.includes("ytm-single-column-watch-next-results-renderer"),
       ),
     ).toBe(true);
+    expect(
+      config.subscriptionsOnly.some((rule) =>
+        rule.selector.includes("ytm-single-column-watch-next-results-renderer"),
+      ),
+    ).toBe(false);
   });
 
   it("defines Instagram's Following feed tabs narrowly", () => {

--- a/tests/platforms.test.ts
+++ b/tests/platforms.test.ts
@@ -7,6 +7,8 @@ describe("platform adapters", () => {
     expect(getPlatformAdapter("x.com")?.id).toBe("x");
     expect(getPlatformAdapter("twitter.com")?.id).toBe("x");
     expect(getPlatformAdapter("www.instagram.com")?.id).toBe("instagram");
+    expect(getPlatformAdapter("www.youtube.com")?.id).toBe("youtube");
+    expect(getPlatformAdapter("m.youtube.com")?.id).toBe("youtube");
   });
 
   it("limits only feed routes on X and Instagram", () => {
@@ -68,6 +70,52 @@ describe("platform adapters", () => {
     expect(instagram.singleItemView?.navigationSelectors).toContain(
       'main [role="toolbar"]',
     );
+  });
+
+  it("limits YouTube feeds but leaves requested videos outside the limiter", () => {
+    const youtube = getPlatformAdapter("youtube.com")!;
+
+    expect(youtube.isFeedRoute(new URL("https://youtube.com/"))).toBe(true);
+    expect(
+      youtube.isFeedRoute(
+        new URL("https://youtube.com/feed/subscriptions"),
+      ),
+    ).toBe(true);
+    expect(
+      youtube.isFeedRoute(new URL("https://youtube.com/watch?v=example")),
+    ).toBe(false);
+    expect(
+      youtube.isFeedRoute(new URL("https://youtube.com/results?search_query=x")),
+    ).toBe(false);
+  });
+
+  it("converts a requested YouTube Short into the standard player", () => {
+    const youtube = getPlatformAdapter("youtube.com")!;
+    const canonical = youtube.surfaceSuppression?.canonicalUrl(
+      new URL("https://youtube.com/shorts/ABC_123"),
+    );
+
+    expect(canonical?.href).toBe("https://youtube.com/watch?v=ABC_123");
+    expect(
+      youtube.surfaceSuppression?.canonicalUrl(
+        new URL("https://youtube.com/watch?v=ABC_123"),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("scopes YouTube Shorts and watch recommendations to platform containers", () => {
+    const youtube = getPlatformAdapter("youtube.com")!;
+    const config = youtube.surfaceSuppression!;
+
+    expect(config.subscriptionsPath).toBe("/feed/subscriptions");
+    expect(config.always.some((rule) => rule.selector.includes('/shorts/'))).toBe(
+      true,
+    );
+    expect(
+      config.subscriptionsOnly.some((rule) =>
+        rule.selector.includes("ytm-single-column-watch-next-results-renderer"),
+      ),
+    ).toBe(true);
   });
 
   it("defines Instagram's Following feed tabs narrowly", () => {

--- a/tests/runtime-messages.test.ts
+++ b/tests/runtime-messages.test.ts
@@ -11,13 +11,20 @@ describe("runtime messages", () => {
       }),
     ).toBe(true);
     expect(isRuntimeMessage({ type: "dopamine-fast:leave-feed" })).toBe(true);
+    expect(
+      isRuntimeMessage({
+        type: "dopamine-fast:add-usage-seconds",
+        platform: "youtube",
+        elapsedSeconds: 5,
+      }),
+    ).toBe(true);
   });
 
   it("rejects malformed and unknown messages", () => {
     expect(
       isRuntimeMessage({
         type: "dopamine-fast:add-usage-seconds",
-        platform: "youtube",
+        platform: "tiktok",
         elapsedSeconds: 5,
       }),
     ).toBe(false);

--- a/tests/surface-suppression.test.ts
+++ b/tests/surface-suppression.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { matchesExactToken } from "../lib/surface-suppression";
+
+describe("surface suppression", () => {
+  it("matches only exact localized navigation labels", () => {
+    expect(matchesExactToken(" Shorts ", ["shorts"])).toBe(true);
+    expect(matchesExactToken("Inicio", ["home", "inicio"])).toBe(true);
+    expect(matchesExactToken("Shorts recomendados", ["shorts"])).toBe(false);
+    expect(matchesExactToken("Página de inicio", ["home", "inicio"])).toBe(
+      false,
+    );
+  });
+});

--- a/tests/usage-history.test.ts
+++ b/tests/usage-history.test.ts
@@ -17,6 +17,7 @@ describe("usage history", () => {
             reddit: 62.4,
             x: -8,
             instagram: Number.POSITIVE_INFINITY,
+            youtube: 12.8,
           },
         },
         { date: "2026-02-31", usedSecondsByPlatform: { reddit: 500 } },
@@ -26,7 +27,12 @@ describe("usage history", () => {
     expect(history.days).toEqual([
       {
         date: "2026-08-03",
-        usedSecondsByPlatform: { reddit: 62, x: 0, instagram: 0 },
+        usedSecondsByPlatform: {
+          reddit: 62,
+          x: 0,
+          instagram: 0,
+          youtube: 13,
+        },
       },
     ]);
   });
@@ -43,7 +49,12 @@ describe("usage history", () => {
         ].join("-");
         return {
           date: key,
-          usedSecondsByPlatform: { reddit: index, x: 0, instagram: 0 },
+          usedSecondsByPlatform: {
+            reddit: index,
+            x: 0,
+            instagram: 0,
+            youtube: 0,
+          },
         };
       },
     );
@@ -72,6 +83,7 @@ describe("usage history", () => {
       reddit: 0,
       x: 0,
       instagram: 0,
+      youtube: 0,
     });
   });
 
@@ -83,7 +95,12 @@ describe("usage history", () => {
         days: [
           {
             date: "2026-08-03",
-            usedSecondsByPlatform: { reddit: 120, x: 30, instagram: 0 },
+            usedSecondsByPlatform: {
+              reddit: 120,
+              x: 30,
+              instagram: 0,
+              youtube: 0,
+            },
           },
         ],
       },
@@ -94,6 +111,7 @@ describe("usage history", () => {
       reddit: 120,
       x: 30,
       instagram: 0,
+      youtube: 0,
     });
   });
 });


### PR DESCRIPTION
## What changed

- add YouTube as a supported network with independent post and time usage counters
- hide Shorts navigation and Shorts shelves across feeds, watch pages, and search
- convert direct `/shorts/{id}` visits to the standard video player
- add an optional Subscriptions-only setting that redirects Home to Subscriptions
- hide related, next-video, Shorts, and end-screen recommendations on watch pages in Subscriptions-only mode
- preserve requested videos, playback controls, channels, search, and comments
- document authenticated selector observations and known desktop/Firefox Android gaps

## Why

YouTube currently exposes habitual discovery and infinite recommendation surfaces that bypass the extension's finite-feed model. This extends the same intentional-access model to YouTube while keeping explicitly requested content available.

## User impact

YouTube Home and Subscriptions can use finite batches and time limits. Shorts are removed from discovery surfaces. Users who enable Subscriptions only see their subscription feed and no watch-page recommendation surfaces.

Existing installations receive backward-compatible defaults: YouTube is enabled, Subscriptions only is disabled, and legacy usage records gain a zero-valued YouTube counter.

## Validation

- TypeScript strict typecheck
- Vitest: 12 files, 42 tests passed
- Firefox MV2 production build and ZIP
- Chrome MV3 production build and ZIP
- authenticated Chrome responsive/mobile DOM inspection at 391×844 in Spanish on Home, Subscriptions, search, and watch routes
- verified watch recommendation selectors do not match the comments section
- verified search Shorts resolve to a scoped shelf container

## Manual follow-up

- reload the newly built Chrome bundle for an end-to-end signed-in smoke test
- verify wide desktop YouTube selectors
- verify Firefox Android before release