### PR TITLE
fix(intervention): block feed interaction during startup

### DIFF
--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -15,15 +15,17 @@ Keep the useful parts of social networks while giving every feed a real end.
 ## Default experience
 
 1. The user opens a supported social-network page.
-2. A configurable opening pause interrupts automatic entry.
-3. The user chooses how many minutes the session should last.
-4. A floating countdown remains visible while the supported feed is active.
-5. Dopamine Fast removes promoted and suggested content.
-6. The first 20 top-level post elements remain visible.
-7. The native feed ends with an inline load-more control after the twentieth
+2. The feed is non-interactive while the extension loads its local policy, so
+   clicks, keyboard actions and scrolling cannot race the opening intervention.
+3. A configurable opening pause interrupts automatic entry.
+4. The user chooses how many minutes the session should last.
+5. A floating countdown remains visible while the supported feed is active.
+6. Dopamine Fast removes promoted and suggested content.
+7. The first 20 top-level post elements remain visible.
+8. The native feed ends with an inline load-more control after the twentieth
    post; no full-screen intervention is shown for a batch boundary.
-8. The user can deliberately reveal 10 additional posts from that control.
-9. Per-network daily hard limits for both time and posts stop further use.
+9. The user can deliberately reveal 10 additional posts from that control.
+10. Per-network daily hard limits for both time and posts stop further use.
 
 ## Time budgets
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ of loading more posts automatically.
 ## Features
 
 - Configurable delay before entering a supported feed.
+- Immediate interaction guard while local settings and the opening
+  intervention load, preventing clicks or scrolling through the feed first.
 - Intentional session duration, adjusted through deliberate button steps, with
   a floating countdown that remains active across same-network SPA and history
   navigation.

--- a/assets/content.css
+++ b/assets/content.css
@@ -31,6 +31,8 @@
   z-index: 2147483647;
   inset: 0;
   display: grid;
+  overflow: hidden;
+  overscroll-behavior: contain;
   align-items: stretch;
   padding: 0;
   background: #111312;
@@ -42,6 +44,7 @@
   position: relative;
   display: flex;
   overflow-y: auto;
+  overscroll-behavior: contain;
   width: 100%;
   min-height: 100%;
   flex-direction: column;

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -3,6 +3,7 @@ import { FeedLimiter } from "../lib/feed-limiter";
 import { InterventionUi } from "../lib/intervention-ui";
 import { IntentionalSearchController } from "../lib/intentional-search";
 import { availableUsageSeconds, localDateKey } from "../lib/models";
+import { PageInteractionGuard } from "../lib/page-interaction-guard";
 import { getPlatformAdapter } from "../lib/platforms";
 import { PreferredFeedController } from "../lib/preferred-feed";
 import { SingleItemViewController } from "../lib/single-item-view";
@@ -37,6 +38,12 @@ export default defineContentScript({
     const adapter = getPlatformAdapter(location.hostname);
     if (!adapter) return;
 
+    const interactionGuard = new PageInteractionGuard();
+    if (adapter.isFeedRoute(new URL(location.href))) {
+      interactionGuard.engage(0);
+    }
+    ctx.onInvalidated(() => interactionGuard.destroy());
+
     if (document.readyState === "loading") {
       await new Promise<void>((resolve) => {
         document.addEventListener("DOMContentLoaded", () => resolve(), {
@@ -64,7 +71,10 @@ export default defineContentScript({
     shadowUi.mount();
 
     const intervention = shadowUi.mounted;
-    if (!intervention) return;
+    if (!intervention) {
+      interactionGuard.destroy();
+      return;
+    }
 
     let limiter: FeedLimiter | undefined;
     let intentionalSearch: IntentionalSearchController | undefined;
@@ -76,8 +86,19 @@ export default defineContentScript({
     let currentUrl = "";
     let activationId = 0;
 
-    const activate = async (preserveUsageSession = false) => {
+    const activate = (preserveUsageSession = false): Promise<void> => {
       const thisActivation = ++activationId;
+      const url = new URL(location.href);
+      if (
+        adapter.isFeedRoute(url) &&
+        (!preserveUsageSession || !usageSession)
+      ) {
+        interactionGuard.engage(thisActivation);
+      } else {
+        interactionGuard.releaseAll();
+      }
+
+      return (async () => {
       if (limiter) sessionPostAllowance = limiter.getAllowance();
       limiter?.destroy();
       limiter = undefined;
@@ -98,7 +119,6 @@ export default defineContentScript({
         intervention.hideAll();
       }
 
-      const url = new URL(location.href);
       const settings = await getSettings();
       if (thisActivation !== activationId) return;
       if (!settings.enabled || !settings.enabledSites[adapter.id]) {
@@ -195,7 +215,7 @@ export default defineContentScript({
       }
       const todayUsage = usageForDate(usageHistory, localDateKey());
 
-      const plannedSeconds = await intervention.showOpening({
+      const opening = intervention.showOpening({
         platformLabel: adapter.label,
         delaySeconds: settings.openingDelaySeconds,
         defaultSessionMinutes: settings.sessionDurationMinutes,
@@ -207,6 +227,8 @@ export default defineContentScript({
           { label: "YouTube", usedSeconds: todayUsage.youtube },
         ],
       });
+      interactionGuard.release(thisActivation);
+      const plannedSeconds = await opening;
       if (thisActivation !== activationId) return;
       if (plannedSeconds <= 0) return;
 
@@ -256,6 +278,7 @@ export default defineContentScript({
       });
       usageSession = session;
       session.start();
+      })().finally(() => interactionGuard.release(thisActivation));
     };
 
     currentUrl = location.href;

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -67,8 +67,16 @@ export default defineContentScript({
       onRemove(ui) {
         ui?.hideAll();
       },
+    }).catch((error: unknown) => {
+      interactionGuard.destroy();
+      throw error;
     });
-    shadowUi.mount();
+    try {
+      shadowUi.mount();
+    } catch (error) {
+      interactionGuard.destroy();
+      throw error;
+    }
 
     const intervention = shadowUi.mounted;
     if (!intervention) {

--- a/lib/intervention-ui.ts
+++ b/lib/intervention-ui.ts
@@ -34,9 +34,6 @@ export class InterventionUi {
   private readonly root: HTMLElement;
   private readonly overlay: HTMLElement;
   private readonly timer: HTMLElement;
-  private previousHtmlOverflow = "";
-  private previousBodyOverflow = "";
-  private pageLocked = false;
   private cancelPendingInteraction?: () => void;
 
   constructor(root: HTMLElement) {
@@ -53,7 +50,6 @@ export class InterventionUi {
     this.cancelPendingInteraction = undefined;
     cancelPendingInteraction?.();
     this.overlay.replaceChildren();
-    this.unlockPage();
   }
 
   hideAll(): void {
@@ -62,7 +58,6 @@ export class InterventionUi {
   }
 
   showOpening(options: OpeningOptions): Promise<number> {
-    this.lockPage();
     const maximumMinutes = Math.max(
       1,
       Math.min(60, Math.ceil(options.availableSeconds / 60)),
@@ -147,7 +142,6 @@ export class InterventionUi {
   }
 
   showSessionEnded(options: SessionEndedOptions): Promise<number> {
-    this.lockPage();
     this.overlay.replaceChildren(
       createSessionEndedView({
         platformLabel: options.platformLabel,
@@ -257,7 +251,6 @@ export class InterventionUi {
     const cancelPendingInteraction = this.cancelPendingInteraction;
     this.cancelPendingInteraction = undefined;
     cancelPendingInteraction?.();
-    this.lockPage();
     this.overlay.replaceChildren(createHardLimitView(platformLabel));
 
     this.requiredElement<HTMLButtonElement>('[data-action="leave"]')
@@ -391,21 +384,5 @@ export class InterventionUi {
     const minutes = Math.floor((safeSeconds % 3600) / 60);
     if (hours === 0) return `${minutes} min`;
     return minutes > 0 ? `${hours} h ${minutes} min` : `${hours} h`;
-  }
-
-  private lockPage(): void {
-    if (this.pageLocked) return;
-    this.pageLocked = true;
-    this.previousHtmlOverflow = document.documentElement.style.overflow;
-    this.previousBodyOverflow = document.body?.style.overflow ?? "";
-    document.documentElement.style.overflow = "hidden";
-    if (document.body) document.body.style.overflow = "hidden";
-  }
-
-  private unlockPage(): void {
-    if (!this.pageLocked) return;
-    this.pageLocked = false;
-    document.documentElement.style.overflow = this.previousHtmlOverflow;
-    if (document.body) document.body.style.overflow = this.previousBodyOverflow;
   }
 }

--- a/lib/page-interaction-guard.ts
+++ b/lib/page-interaction-guard.ts
@@ -1,0 +1,56 @@
+const BLOCKED_EVENT_TYPES = [
+  "auxclick",
+  "click",
+  "keydown",
+  "pointerdown",
+  "touchmove",
+  "touchstart",
+  "wheel",
+] as const;
+const LISTENER_OPTIONS: AddEventListenerOptions = {
+  capture: true,
+  passive: false,
+};
+
+export class PageInteractionGuard {
+  private active = false;
+  private owner: number | undefined;
+
+  constructor(private readonly target: EventTarget = window) {}
+
+  engage(owner: number): void {
+    this.owner = owner;
+    if (this.active) return;
+    this.active = true;
+    BLOCKED_EVENT_TYPES.forEach((type) => {
+      this.target.addEventListener(type, this.blockInteraction, LISTENER_OPTIONS);
+    });
+  }
+
+  release(owner: number): void {
+    if (owner !== this.owner) return;
+    this.releaseAll();
+  }
+
+  releaseAll(): void {
+    if (!this.active) return;
+    this.active = false;
+    this.owner = undefined;
+    BLOCKED_EVENT_TYPES.forEach((type) => {
+      this.target.removeEventListener(
+        type,
+        this.blockInteraction,
+        LISTENER_OPTIONS,
+      );
+    });
+  }
+
+  destroy(): void {
+    this.releaseAll();
+  }
+
+  private readonly blockInteraction = (event: Event): void => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+}

--- a/tests/page-interaction-guard.test.ts
+++ b/tests/page-interaction-guard.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { PageInteractionGuard } from "../lib/page-interaction-guard";
+
+describe("page interaction guard", () => {
+  it("blocks interaction until its current activation releases it", () => {
+    const target = new EventTarget();
+    const guard = new PageInteractionGuard(target);
+
+    guard.engage(1);
+    guard.engage(2);
+    guard.release(1);
+    const blockedClick = new Event("click", { cancelable: true });
+    target.dispatchEvent(blockedClick);
+
+    expect(blockedClick.defaultPrevented).toBe(true);
+
+    guard.release(2);
+    const allowedClick = new Event("click", { cancelable: true });
+    target.dispatchEvent(allowedClick);
+
+    expect(allowedClick.defaultPrevented).toBe(false);
+  });
+
+  it("restores interaction when destroyed", () => {
+    const target = new EventTarget();
+    const guard = new PageInteractionGuard(target);
+    guard.engage(1);
+
+    guard.destroy();
+    const event = new Event("wheel", { cancelable: true });
+    target.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

- install a temporary interaction guard at `document_start` on recognized feed routes
- block clicks, pointer/touch input, keyboard actions and scrolling while local policy and usage state load
- release the guard synchronously once the opening or hard-limit intervention is rendered, or immediately when the route/settings do not require an intervention
- prevent stale overlapping activations from releasing a newer guard
- restore every event listener during teardown

## Why

The content script waited for `DOMContentLoaded`, mounted the shadow UI and loaded local settings before rendering the opening intervention. During that window the native feed remained interactive, allowing users to click or scroll before the limit UI appeared.

## Impact

Supported feeds are non-interactive from the earliest content-script phase until Dopamine Fast has made and rendered its entry decision. Existing active sessions and non-feed routes are not delayed.

## Validation

- `npm audit --audit-level=high`: 0 vulnerabilities
- TypeScript: passed
- Vitest: 50 tests across 14 files passed
- Firefox MV2 production build: passed
- Chrome MV3 production build: passed

This PR follows #39, which was merged before this startup guard could be included.