### PR TITLE
feat(feed): allow unlimited post batches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ The product principles are:
 1. Preserve useful, user-requested access to social networks.
 2. Add friction before and during habitual feed consumption.
 3. Give feeds a visible end through finite post batches.
-4. Keep hard daily limits outside the in-page unlock flow.
+4. Keep the hard daily time limit outside the in-page unlock flow.
 5. Store only preferences and aggregate counters, locally.
 6. Request the minimum browser and host permissions required.
 7. Fail safely when a platform changes its DOM.
@@ -68,17 +68,17 @@ On a supported feed route, the content script:
    feed.
 3. Blocks entry when the per-network daily time ceiling is exhausted.
 4. Shows a configurable opening delay and asks for an intended session length.
-5. Reserves the initial post allowance and starts the finite-feed limiter.
+5. Starts the finite-feed limiter with the configured initial batch.
 6. Counts time only while the document is visible and shows a floating timer.
 7. Stops at the selected session duration and asks the user to leave or choose
    another block.
 8. Enforces the daily time ceiling without an in-page extension or reset.
 9. Shows an end-of-batch intervention before revealing more posts.
 
-Post and time budgets use independent per-network enforcement:
+Post counters and time budgets are independent per network:
 
-- `DailyState.revealedByPlatform` and `DailyState.unlocksByPlatform` enforce
-  post and unlock limits independently for each supported network.
+- `DailyState.revealedByPlatform` and `DailyState.unlocksByPlatform` record
+  post and unlock totals for each supported network without imposing a cap.
 - `DailyState.revealed` and `DailyState.unlocks` remain aggregate reporting
   totals derived from their per-platform records.
 - `DailyUsageState.usedSecondsByPlatform` enforces an independent time ceiling
@@ -86,10 +86,8 @@ Post and time budgets use independent per-network enforcement:
 - The effective time ceiling is captured when the day's state is created.
   Changing the setting applies on the next local calendar day.
 
-Mode behavior currently differs mainly in unlock policy: balanced mode permits
-two extra batches per network per day, while gentle and strict are still
-primarily bounded by the per-network daily post maximum. The stricter fail-closed behavior described
-in `PRODUCT_SPEC.md` is not fully implemented; do not claim otherwise.
+Post batches can be unlocked repeatedly. Each unlock still requires the
+configured inline delay and press-and-hold interaction.
 
 ## Technology and extension constraints
 
@@ -167,9 +165,10 @@ Specific responsibilities:
 - `entrypoints/content.ts` composes services, reacts to SPA navigation/settings
   changes and owns activation cancellation. Keep policy and DOM algorithms out
   of it.
-- `entrypoints/background.ts` is the single owner for daily post/time mutations
-  and privileged options/leave navigation. Keep its message surface validated
-  and route new daily-state writes through its serialized queue.
+- `entrypoints/background.ts` is the single owner for daily post counters and
+  time mutations and privileged options/leave navigation. Keep its message
+  surface validated and route new daily-state writes through its serialized
+  queue.
 - `models.ts` must remain deterministic and easy to unit test. Put defaults,
   clamps, date normalization and pure budget calculations here.
 - `storage.ts` owns storage key names and all persistent reads/writes. Other
@@ -214,8 +213,8 @@ Preserve these invariants:
 - Repeated activation must cancel stale asynchronous UI results.
 - Teardown must clear timers, observers and listeners and restore page state.
 
-Daily post reservations, elapsed-time increments and post-counter resets are
-serialized through the background owner. Content scripts watch persisted time
+Daily post counter increments and elapsed-time increments are serialized
+through the background owner. Content scripts watch persisted time
 usage and lower their local remaining-time view when another tab advances it.
 Preserve this ownership model and add browser-level multi-tab coverage when an
 end-to-end harness is introduced.
@@ -259,9 +258,9 @@ Treat the host page as untrusted input:
 - Virtualized feeds must count stable post identities in memory so removing old
   DOM nodes cannot reopen the current batch. Do not persist those identities.
 
-A “hard” limit means no bypass exposed by the extension UI. Users still control
-their browser, storage and installed extensions; documentation must not imply
-tamper-proof enforcement.
+A “hard” daily time limit means no bypass exposed by the extension UI. Users
+still control their browser, storage and installed extensions; documentation
+must not imply tamper-proof enforcement.
 
 ## Code Review Rules
 
@@ -272,7 +271,7 @@ enforce. Flag a change when it:
   documented need and privacy analysis;
 - sends local state or page-derived data off-device;
 - inserts host-page content through `innerHTML` or introduces remote code;
-- weakens a hard limit, exposes a time-counter reset or lets current-day
+- weakens the hard daily time limit, exposes a time-counter reset or lets current-day
   settings increases take effect immediately;
 - mutates daily state outside `storage.ts` or adds another non-serialized
   read-modify-write path;
@@ -299,8 +298,7 @@ For every new setting:
 5. Add model tests for invalid, missing and boundary values.
 6. Update `PRODUCT_SPEC.md` and `README.md` when behavior is user-visible.
 
-Do not provide an options-page reset for elapsed time. The existing reset
-button resets the post counter only.
+Do not provide an options-page reset for elapsed time.
 
 ## Testing strategy
 

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -25,7 +25,8 @@ Keep the useful parts of social networks while giving every feed a real end.
 8. The native feed ends with an inline load-more control after the twentieth
    post; no full-screen intervention is shown for a batch boundary.
 9. The user can deliberately reveal 10 additional posts from that control.
-10. Per-network daily hard limits for both time and posts stop further use.
+10. A per-network daily hard time limit stops further use, while post batches
+    can be deliberately unlocked without a daily post maximum.
 
 ## Time budgets
 
@@ -49,8 +50,9 @@ Keep the useful parts of social networks while giving every feed a real end.
 - A separate daily limit applies to each supported network. It persists across
   reloads and sessions, resets on the next local calendar day and has no
   in-page unlock.
-- Daily post and time mutations are serialized by the extension background
-  context, and active tabs reconcile against persisted usage from other tabs.
+- Daily post counters and time mutations are serialized by the extension
+  background context, and active tabs reconcile against persisted time usage
+  from other tabs.
 - Aggregate elapsed seconds are retained locally for the 30 most recent days
   with activity so usage statistics survive calendar resets. Active session
   countdowns are not stored as history.
@@ -59,35 +61,23 @@ Keep the useful parts of social networks while giving every feed a real end.
 
 ## Unlock flow
 
-The end of a batch is rendered inside the native feed. The inline control shows
-how many posts remain in that network's daily allowance, waits through the configured
-pause and requires holding the load-more button for the configured duration.
-Completing it reveals only the next configured batch.
+The end of a batch is rendered inside the native feed. The inline control waits
+through the configured pause and requires holding the load-more button for the
+configured duration. Completing it reveals only the next configured batch, and
+the flow can be repeated without a daily post maximum.
 Virtualized feeds are counted by stable post identity for the active page
 session, so recycling DOM elements cannot reset the batch.
 Blocked posts retain their layout geometry while becoming invisible and
-non-interactive. Together with a terminal control that reserves the remaining
+non-interactive. Together with a boundary control that reserves the remaining
 viewport, this keeps a platform's native infinite-loader sentinel outside the
 visible area while the batch is closed.
 
-## Modes
+## Batch behavior
 
-### Gentle
-
-- Batch limit is active.
-- Additional batches can be unlocked repeatedly.
-- Suggested and promoted content remains blocked.
-
-### Balanced
-
-- One initial batch and two additional batches per network.
-- The inline pause and hold are required.
-
-### Strict
-
-- Fixed daily maximum.
-- Limit increases take effect the following day.
-- Supported feeds fail closed if their adapter becomes uncertain.
+- The configured initial batch is revealed after the opening intervention.
+- Additional configured batches can be unlocked repeatedly without a post cap.
+- Every additional batch requires the inline pause and hold interaction.
+- Suggested and promoted content remains blocked when suppression is enabled.
 
 ## Platform scope
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,9 @@ available while adding deliberate friction around habitual scrolling:
 6. Reaching the end shows an inline control for loading the next batch.
 7. A per-network daily time ceiling cannot be extended from the page.
 
-Daily post allowances and time ceilings are tracked independently for Reddit,
-X/Twitter, Instagram, and YouTube.
+Daily post counts and time ceilings are tracked independently for Reddit,
+X/Twitter, Instagram, and YouTube. Post counts do not impose a maximum: every
+completed batch gate can reveal another configured batch.
 Preferences and aggregate counters stay in browser extension local storage.
 Elapsed seconds per network are retained for the 30 most recent days with
 activity; active session countdowns are not stored in that history.
@@ -76,10 +77,9 @@ hold before the next finite batch is revealed.
   hides Home. Next-video and recommendation surfaces around requested videos
   are always hidden.
 - Non-extendable daily time ceiling for each network.
-- Finite initial and additional post batches.
+- Finite initial and additional post batches with unlimited successive unlocks.
 - Stable per-session post counting for virtualized feeds such as Reddit.
 - Optional delay and press-and-hold step before revealing another batch.
-- Gentle, balanced, and strict friction modes.
 - Best-effort suppression of suggested and promoted surfaces.
 - Media autoplay prevention.
 - Per-network enable or disable controls.
@@ -146,7 +146,7 @@ entrypoints/content.ts
        └─ inline load-more gate
 
 entrypoints/background.ts
-  └─ serialized daily post and time mutations
+  └─ serialized daily post counters and time mutations
 
 entrypoints/options/
   └─ local settings UI
@@ -183,9 +183,9 @@ the browser's local storage permission. It has:
 - no platform API credentials;
 - no remote backend.
 
-A “hard” limit means that the extension exposes no in-page bypass. It is not
-tamper-proof: users retain control over their browser, extension storage, and
-installed software.
+A “hard” daily time limit means that the extension exposes no in-page bypass.
+It is not tamper-proof: users retain control over their browser, extension
+storage, and installed software.
 
 ## Current limitations
 
@@ -193,8 +193,6 @@ installed software.
   verification.
 - Active tabs reconcile their daily time counters whenever the background
   owner persists usage from any supported tab.
-- Gentle and strict modes do not yet differ as much as the complete product
-  specification intends.
 - There is not yet a published browser-store installation.
 
 ## Validation

--- a/docs/STORE_LISTING.md
+++ b/docs/STORE_LISTING.md
@@ -4,7 +4,8 @@ The screenshots in `docs/screenshots/` are the canonical assets for both the
 README and the Firefox Add-ons listing. Upload them to AMO in this order:
 
 1. `settings.png` — **Set intentional limits locally.** Configure session
-   length, daily ceilings, feed size, and network-specific protections.
+   length, the daily time ceiling, batch sizes, and network-specific
+   protections.
 2. `opening-pause.png` — **Pause before entering a feed.** Review today's use
    and choose a defined session with deliberate time steps.
 3. `end-of-batch.png` — **Give every feed a visible ending.** Load another

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,7 +1,6 @@
 import {
   addUsageSecondsFromStorage,
   reserveAllowanceFromStorage,
-  resetDailyStateFromStorage,
 } from "../lib/storage";
 import { isRuntimeMessage } from "../lib/runtime-messages";
 import { SerialQueue } from "../lib/serial-queue";
@@ -32,11 +31,6 @@ export function createRuntimeMessageHandler() {
             message.elapsedSeconds,
           ),
         }));
-      case "dopamine-fast:reset-daily-state":
-        return mutations.run(async () => {
-          await resetDailyStateFromStorage();
-          return { ok: true };
-        });
       case "dopamine-fast:open-options":
         return browser.runtime.openOptionsPage().then(() => ({ ok: true }));
       case "dopamine-fast:leave-feed":

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -110,7 +110,7 @@
             <p>Every batch truly ends. You decide whether to open another.</p>
           </div>
 
-          <div class="number-grid">
+          <div class="number-grid number-grid--two">
             <label class="number-field">
               <span>First batch</span>
               <input
@@ -137,18 +137,6 @@
               <small>posts</small>
             </label>
 
-            <label class="number-field">
-              <span>Daily maximum</span>
-              <input
-                id="daily-limit"
-                name="dailyLimit"
-                type="number"
-                min="10"
-                max="500"
-                step="10"
-              />
-              <small>posts per network</small>
-            </label>
           </div>
         </section>
 
@@ -157,30 +145,6 @@
           <div class="section-heading">
             <h2>Friction</h2>
             <p>How much effort it takes to intentionally choose another batch.</p>
-          </div>
-
-          <div class="mode-grid">
-            <label class="mode-card">
-              <input type="radio" name="mode" value="gentle" />
-              <span>
-                <strong>Gentle</strong>
-                <small>Extra batches without an unlock limit.</small>
-              </span>
-            </label>
-            <label class="mode-card">
-              <input type="radio" name="mode" value="balanced" />
-              <span>
-                <strong>Balanced</strong>
-                <small>Up to two unlocks per day.</small>
-              </span>
-            </label>
-            <label class="mode-card">
-              <input type="radio" name="mode" value="strict" />
-              <span>
-                <strong>Strict</strong>
-                <small>The daily maximum always applies.</small>
-              </span>
-            </label>
           </div>
 
           <label class="field">
@@ -220,9 +184,6 @@
         <footer class="form-footer">
           <p id="save-status" role="status" aria-live="polite"></p>
           <div>
-            <button class="button button--quiet" id="reset-day" type="button">
-              Reset today's post count
-            </button>
             <button class="button button--primary" type="submit">
               Save changes
             </button>

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -2,12 +2,10 @@ import "./style.css";
 import {
   DEFAULT_SETTINGS,
   sanitizeSettings,
-  type GuardMode,
   type Settings,
 } from "../../lib/models";
 import {
   getSettings,
-  resetDailyState,
   saveSettings,
 } from "../../lib/storage";
 
@@ -28,7 +26,6 @@ const controls = {
   batchSize: requiredElement<HTMLInputElement>("#batch-size"),
   unlockBatchSize:
     requiredElement<HTMLInputElement>("#unlock-batch-size"),
-  dailyLimit: requiredElement<HTMLInputElement>("#daily-limit"),
   holdSeconds: requiredElement<HTMLInputElement>("#hold-seconds"),
   holdOutput: requiredElement<HTMLOutputElement>("#hold-output"),
   reddit: requiredElement<HTMLInputElement>("#site-reddit"),
@@ -66,7 +63,6 @@ function render(settings: Settings): void {
   controls.unlockDelay.value = String(settings.unlockDelaySeconds);
   controls.batchSize.value = String(settings.batchSize);
   controls.unlockBatchSize.value = String(settings.unlockBatchSize);
-  controls.dailyLimit.value = String(settings.dailyLimit);
   controls.holdSeconds.value = String(settings.holdSeconds);
   controls.reddit.checked = settings.enabledSites.reddit;
   controls.x.checked = settings.enabledSites.x;
@@ -77,27 +73,18 @@ function render(settings: Settings): void {
   controls.youtubeSubscriptionsOnly.checked = settings.youtubeSubscriptionsOnly;
   controls.blockSuggested.checked = settings.blockSuggested;
   controls.disableAutoplay.checked = settings.disableAutoplay;
-  requiredElement<HTMLInputElement>(
-    `input[name="mode"][value="${settings.mode}"]`,
-  ).checked = true;
   updateOutputs();
 }
 
 function readSettings(): Settings {
-  const mode =
-    document.querySelector<HTMLInputElement>('input[name="mode"]:checked')
-      ?.value ?? DEFAULT_SETTINGS.mode;
-
   return sanitizeSettings({
     enabled: controls.enabled.checked,
-    mode: mode as GuardMode,
     openingDelaySeconds: Number(controls.openingDelay.value),
     sessionDurationMinutes: Number(controls.sessionDuration.value),
     dailyUsageLimitMinutes: Number(controls.dailyUsageLimit.value),
     unlockDelaySeconds: Number(controls.unlockDelay.value),
     batchSize: Number(controls.batchSize.value),
     unlockBatchSize: Number(controls.unlockBatchSize.value),
-    dailyLimit: Number(controls.dailyLimit.value),
     holdSeconds: Number(controls.holdSeconds.value),
     blockSuggested: controls.blockSuggested.checked,
     disableAutoplay: controls.disableAutoplay.checked,
@@ -145,18 +132,10 @@ form.addEventListener("submit", async (event) => {
   event.preventDefault();
   await saveSettings(readSettings());
   status.textContent =
-    "Saved. If you already used a network today, its new ceiling applies tomorrow.";
+    "Saved. Changes to today's time ceiling apply tomorrow.";
   window.setTimeout(() => {
     status.textContent = "";
   }, 2400);
 });
-
-requiredElement<HTMLButtonElement>("#reset-day").addEventListener(
-  "click",
-  async () => {
-    await resetDailyState();
-    status.textContent = "Today's post count has been reset.";
-  },
-);
 
 void getSettings().then(render);

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -118,7 +118,6 @@ input {
 
 .field,
 .number-grid,
-.mode-grid,
 .toggle-list {
   grid-column: 2;
 }
@@ -142,8 +141,7 @@ input {
   accent-color: var(--ink);
 }
 
-.number-grid,
-.mode-grid {
+.number-grid {
   display: grid;
   gap: 10px;
 }
@@ -176,35 +174,8 @@ input {
 }
 
 .number-field small,
-.mode-card small,
 .master-toggle small {
   color: var(--muted);
-}
-
-.mode-card {
-  display: block;
-  cursor: pointer;
-}
-
-.mode-card input {
-  position: absolute;
-  opacity: 0;
-  pointer-events: none;
-}
-
-.mode-card > span {
-  display: grid;
-  gap: 3px;
-  min-height: 74px;
-  padding: 16px;
-  border: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.2);
-}
-
-.mode-card input:checked + span {
-  border-color: var(--ink);
-  background: var(--acid);
-  box-shadow: inset 7px 0 0 var(--ink);
 }
 
 .toggle-list {
@@ -292,11 +263,6 @@ input {
   background: var(--ink);
 }
 
-.button--quiet {
-  color: var(--ink);
-  background: var(--paper);
-}
-
 @media (min-width: 720px) {
   .settings-shell {
     padding-inline: 32px;
@@ -326,9 +292,6 @@ input {
     text-align: left;
   }
 
-  .mode-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/lib/batch-gate-ui.ts
+++ b/lib/batch-gate-ui.ts
@@ -1,7 +1,5 @@
 export interface BatchGateOptions {
   unlockSize: number;
-  remainingToday: number;
-  canUnlock: boolean;
   unlockDelaySeconds: number;
   holdSeconds: number;
   onUnlock(): Promise<number>;
@@ -50,8 +48,6 @@ export class BatchGateUi {
   ): void {
     const renderKey = [
       options.unlockSize,
-      options.remainingToday,
-      options.canUnlock,
       options.unlockDelaySeconds,
       options.holdSeconds,
     ].join(":");
@@ -138,13 +134,7 @@ export class BatchGateUi {
 
     gate.append(label, copy);
 
-    if (!options.canUnlock) {
-      copy.textContent = "You have reached today's post limit.";
-      this.shadow.append(style, gate);
-      return;
-    }
-
-    copy.textContent = `${options.remainingToday} posts remain in today's limit.`;
+    copy.textContent = "Load another finite batch when you're ready.";
     const button = document.createElement("button");
     button.type = "button";
     button.disabled = options.unlockDelaySeconds > 0;
@@ -202,7 +192,7 @@ export class BatchGateUi {
         .onUnlock()
         .then((granted) => {
           if (granted <= 0) {
-            this.render({ ...options, canUnlock: false, remainingToday: 0 });
+            throw new Error("No posts were granted");
           }
         })
         .catch(() => {

--- a/lib/feed-limiter.ts
+++ b/lib/feed-limiter.ts
@@ -5,8 +5,8 @@ import {
 } from "./platforms";
 import { BatchGateUi } from "./batch-gate-ui";
 import { planFeedVisibility } from "./feed-boundary";
-import { dailyStateItem, reserveAllowance } from "./storage";
-import { availableAllowance, normalizeDailyState, type Settings } from "./models";
+import { reserveAllowance } from "./storage";
+import type { Settings } from "./models";
 
 interface OriginalProperty {
   value: string;
@@ -27,7 +27,6 @@ export class FeedLimiter {
   private readonly gate = new BatchGateUi();
   private readonly mutationObserver: MutationObserver;
   private processingTimer?: number;
-  private gateRequestId = 0;
   private nextFallbackPostKey = 1;
   private destroyed = false;
 
@@ -145,7 +144,6 @@ export class FeedLimiter {
     placement: "before" | "after",
   ): void {
     if (!boundary) {
-      this.gateRequestId += 1;
       this.gate.hide();
       return;
     }
@@ -153,34 +151,18 @@ export class FeedLimiter {
       this.gate.ensurePlacement(boundary, placement);
       return;
     }
-    const requestId = ++this.gateRequestId;
-    void this.loadGate(boundary, placement, requestId);
+    this.showGate(boundary, placement);
   }
 
-  private async loadGate(
+  private showGate(
     boundary: HTMLElement,
     placement: "before" | "after",
-    requestId: number,
-  ): Promise<void> {
-    const state = normalizeDailyState(await dailyStateItem.getValue());
-    if (this.destroyed || requestId !== this.gateRequestId) return;
-    const remainingToday = availableAllowance(
-      this.settings,
-      state,
-      this.adapter.id,
-    );
-    const balancedUnlockAvailable =
-      this.settings.mode !== "balanced" ||
-      state.unlocksByPlatform[this.adapter.id] < 2;
-    const canUnlock = remainingToday > 0 && balancedUnlockAvailable;
-
+  ): void {
     const showGate = placement === "after"
       ? this.gate.showAfter.bind(this.gate)
       : this.gate.showBefore.bind(this.gate);
     showGate(boundary, {
-      unlockSize: Math.min(this.settings.unlockBatchSize, remainingToday),
-      remainingToday,
-      canUnlock,
+      unlockSize: this.settings.unlockBatchSize,
       unlockDelaySeconds: this.settings.unlockDelaySeconds,
       holdSeconds: this.settings.holdSeconds,
       onUnlock: async () => {

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,15 +1,12 @@
 export type PlatformId = "reddit" | "x" | "instagram" | "youtube";
-export type GuardMode = "gentle" | "balanced" | "strict";
 
 export interface Settings {
   enabled: boolean;
-  mode: GuardMode;
   openingDelaySeconds: number;
   sessionDurationMinutes: number;
   dailyUsageLimitMinutes: number;
   batchSize: number;
   unlockBatchSize: number;
-  dailyLimit: number;
   unlockDelaySeconds: number;
   holdSeconds: number;
   blockSuggested: boolean;
@@ -36,13 +33,11 @@ export interface DailyUsageState {
 
 export const DEFAULT_SETTINGS: Settings = {
   enabled: true,
-  mode: "balanced",
   openingDelaySeconds: 5,
   sessionDurationMinutes: 10,
   dailyUsageLimitMinutes: 30,
   batchSize: 20,
   unlockBatchSize: 10,
-  dailyLimit: 60,
   unlockDelaySeconds: 5,
   holdSeconds: 2,
   blockSuggested: true,
@@ -63,14 +58,7 @@ const clampInteger = (value: number, minimum: number, maximum: number) =>
 
 export function sanitizeSettings(input: Partial<Settings>): Settings {
   return {
-    ...DEFAULT_SETTINGS,
-    ...input,
-    mode:
-      input.mode === "gentle" ||
-      input.mode === "balanced" ||
-      input.mode === "strict"
-        ? input.mode
-        : DEFAULT_SETTINGS.mode,
+    enabled: sanitizeBoolean(input.enabled, DEFAULT_SETTINGS.enabled),
     openingDelaySeconds: clampInteger(
       input.openingDelaySeconds ?? DEFAULT_SETTINGS.openingDelaySeconds,
       0,
@@ -96,11 +84,6 @@ export function sanitizeSettings(input: Partial<Settings>): Settings {
       5,
       50,
     ),
-    dailyLimit: clampInteger(
-      input.dailyLimit ?? DEFAULT_SETTINGS.dailyLimit,
-      10,
-      500,
-    ),
     unlockDelaySeconds: clampInteger(
       input.unlockDelaySeconds ?? DEFAULT_SETTINGS.unlockDelaySeconds,
       0,
@@ -110,6 +93,14 @@ export function sanitizeSettings(input: Partial<Settings>): Settings {
       input.holdSeconds ?? DEFAULT_SETTINGS.holdSeconds,
       1,
       10,
+    ),
+    blockSuggested: sanitizeBoolean(
+      input.blockSuggested,
+      DEFAULT_SETTINGS.blockSuggested,
+    ),
+    disableAutoplay: sanitizeBoolean(
+      input.disableAutoplay,
+      DEFAULT_SETTINGS.disableAutoplay,
     ),
     xFollowingOnly:
       typeof input.xFollowingOnly === "boolean"
@@ -243,17 +234,6 @@ export function availableUsageSeconds(
   return Math.max(
     0,
     dailyLimitSeconds - state.usedSecondsByPlatform[platform],
-  );
-}
-
-export function availableAllowance(
-  settings: Settings,
-  state: DailyState,
-  platform: PlatformId,
-): number {
-  return Math.max(
-    0,
-    settings.dailyLimit - state.revealedByPlatform[platform],
   );
 }
 

--- a/lib/runtime-messages.ts
+++ b/lib/runtime-messages.ts
@@ -12,7 +12,6 @@ export type RuntimeMessage =
       platform: PlatformId;
       elapsedSeconds: number;
     }
-  | { type: "dopamine-fast:reset-daily-state" }
   | { type: "dopamine-fast:open-options" }
   | { type: "dopamine-fast:leave-feed" };
 
@@ -39,7 +38,6 @@ export function isRuntimeMessage(value: unknown): value is RuntimeMessage {
         isPlatform(candidate.platform) &&
         isFiniteNumber(candidate.elapsedSeconds)
       );
-    case "dopamine-fast:reset-daily-state":
     case "dopamine-fast:open-options":
     case "dopamine-fast:leave-feed":
       return true;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -81,16 +81,11 @@ export async function reserveAllowanceFromStorage(
   requested: number,
   isUnlock = false,
 ): Promise<number> {
-  const settings = await getSettings();
   const stored = await dailyStateItem.getValue();
   const current = normalizeDailyState(stored);
-  const granted = Math.min(
-    Math.max(0, requested),
-    Math.max(
-      0,
-      settings.dailyLimit - current.revealedByPlatform[platform],
-    ),
-  );
+  const granted = Number.isFinite(requested)
+    ? Math.max(0, Math.round(requested))
+    : 0;
 
   if (granted === 0) {
     if (current.date !== stored.date) {
@@ -184,14 +179,4 @@ export async function addUsageSecondsFromStorage(
   );
 
   return Math.max(0, dailyLimitSeconds - usedSeconds);
-}
-
-export async function resetDailyState(): Promise<void> {
-  await browser.runtime.sendMessage<RuntimeMessage>({
-    type: "dopamine-fast:reset-daily-state",
-  });
-}
-
-export async function resetDailyStateFromStorage(): Promise<void> {
-  await dailyStateItem.setValue(emptyDailyState());
 }

--- a/tests/lifecycle.integration.test.ts
+++ b/tests/lifecycle.integration.test.ts
@@ -114,7 +114,6 @@ describe("extension lifecycle integration", () => {
     await settingsItem.setValue({
       ...DEFAULT_SETTINGS,
       dailyUsageLimitMinutes: 5,
-      dailyLimit: 60,
     });
   });
 
@@ -122,12 +121,12 @@ describe("extension lifecycle integration", () => {
     vi.useRealTimers();
   });
 
-  it("serializes simultaneous post and time usage from two tabs", async () => {
+  it("tracks unlimited post batches and serializes time usage from two tabs", async () => {
     const [firstGrant, secondGrant] = await Promise.all([
       reserveAllowance("reddit", 40),
       reserveAllowance("reddit", 40),
     ]);
-    expect(firstGrant + secondGrant).toBe(60);
+    expect(firstGrant + secondGrant).toBe(80);
 
     const firstTab = new FakeTabLifecycle();
     const secondTab = new FakeTabLifecycle();
@@ -162,7 +161,7 @@ describe("extension lifecycle integration", () => {
       dailyStateItem.getValue(),
       dailyUsageStateItem.getValue(),
     ]);
-    expect(postState.revealedByPlatform.reddit).toBe(60);
+    expect(postState.revealedByPlatform.reddit).toBe(80);
     expect(usageState.usedSecondsByPlatform.reddit).toBe(14);
   });
 

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_SETTINGS,
-  availableAllowance,
   availableUsageSeconds,
   emptyDailyState,
   emptyDailyUsageState,
@@ -19,7 +18,6 @@ describe("settings", () => {
       dailyUsageLimitMinutes: 900,
       batchSize: 0,
       unlockBatchSize: 300,
-      dailyLimit: -10,
       holdSeconds: 0,
       xFollowingOnly: "yes" as unknown as boolean,
       instagramFollowingOnly: "yes" as unknown as boolean,
@@ -35,7 +33,6 @@ describe("settings", () => {
     expect(settings.dailyUsageLimitMinutes).toBe(240);
     expect(settings.batchSize).toBe(5);
     expect(settings.unlockBatchSize).toBe(50);
-    expect(settings.dailyLimit).toBe(10);
     expect(settings.holdSeconds).toBe(1);
     expect(settings.xFollowingOnly).toBe(false);
     expect(settings.instagramFollowingOnly).toBe(false);
@@ -65,6 +62,19 @@ describe("settings", () => {
     expect(settings.youtubeSubscriptionsOnly).toBe(true);
     expect(settings.enabledSites.youtube).toBe(false);
   });
+
+  it("drops legacy post-limit and friction-mode settings", () => {
+    const settings = sanitizeSettings({
+      mode: "strict",
+      dailyLimit: 10,
+    } as Partial<typeof DEFAULT_SETTINGS> & {
+      mode: string;
+      dailyLimit: number;
+    });
+
+    expect(settings).not.toHaveProperty("mode");
+    expect(settings).not.toHaveProperty("dailyLimit");
+  });
 });
 
 describe("daily state", () => {
@@ -81,33 +91,6 @@ describe("daily state", () => {
     };
 
     expect(normalizeDailyState(stale, today)).toEqual(emptyDailyState(today));
-  });
-
-  it("calculates the remaining allowance", () => {
-    const state = {
-      ...emptyDailyState(today),
-      revealed: 45,
-      revealedByPlatform: {
-        reddit: 35,
-        x: 10,
-        instagram: 0,
-        youtube: 0,
-      },
-    };
-    expect(
-      availableAllowance(
-        { ...DEFAULT_SETTINGS, dailyLimit: 60 },
-        state,
-        "reddit",
-      ),
-    ).toBe(25);
-    expect(
-      availableAllowance(
-        { ...DEFAULT_SETTINGS, dailyLimit: 60 },
-        state,
-        "instagram",
-      ),
-    ).toBe(60);
   });
 
   it("migrates legacy daily state to per-network unlock counters", () => {


### PR DESCRIPTION
## What changed?

Post batches can now be unlocked indefinitely while preserving the inline end-of-batch gate, configured batch sizes, unlock delay and press-and-hold interaction.

The daily post maximum, the two-unlock Balanced cap and their now-unused settings controls were removed. Existing stored `dailyLimit` and `mode` values are ignored safely. Per-network daily post counts remain local aggregate counters and no longer block additional batches.

The README, product specification, contributor guidance and store-listing copy now describe unlimited successive post batches. The daily time ceiling remains unchanged and non-extendable from the feed.

## Why?

The post allowance was enforced in two places: storage capped reservations at `dailyLimit`, and the feed limiter stopped Balanced mode after two unlocks. That made the end-of-batch control terminal even though the desired behavior is progressive loading without a post cap.

## How was it tested?

- [x] `npm run validate` — typecheck, 50 unit/integration tests, Firefox build and Chromium build
- [x] `npm run zip` — Firefox, Chromium and source archives
- [ ] Firefox smoke test
- [ ] Chromium smoke test
- [ ] Firefox for Android smoke test

## Contribution checklist

- [x] The PR has one clear purpose and its title follows Conventional Commits.
- [x] The PR targets `main`; it has no dependency on another open PR.
- [x] I added or updated tests for behavior that can be tested automatically.
- [x] I documented user-facing settings and behavior changes.
- [x] I did not add analytics, remote data collection or new permissions.
- [x] Platform selectors and route boundaries are unchanged.
- [ ] I included screenshots or a short recording for the options-page change.

## Notes for reviewers

The persisted daily post counters are intentionally retained as aggregate local metrics, but they no longer influence allowance grants. Manual browser and network smoke testing remains outstanding.