### PR TITLE
fix(media): allow manual playback after autoplay block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ lib/
   batch-gate-ui.ts       Inline end-of-batch control rendered inside the native feed
   feed-boundary.ts       Pure contiguous visibility planning for finite batches
   feed-limiter.ts        DOM observation, post visibility and batch boundaries
+  media-autoplay.ts      One-time autoplay prevention per media element
   usage-session.ts       Visible-tab session timer and persistence lifecycle
   usage-history.ts       Pure normalization and retention for usage statistics
   preferred-feed.ts      Optional preferred-feed selection and tab restoration

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -79,6 +79,12 @@ visible area while the batch is closed.
 - Every additional batch requires the inline pause and hold interaction.
 - Suggested and promoted content remains blocked when suppression is enabled.
 
+## Media behavior
+
+- When autoplay prevention is enabled, each newly discovered video or audio
+  element is stopped once and has its autoplay flag disabled.
+- Deliberate playback is not interrupted by later feed mutation scans.
+
 ## Platform scope
 
 ### Reddit

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ hold before the next finite batch is revealed.
 - Stable per-session post counting for virtualized feeds such as Reddit.
 - Optional delay and press-and-hold step before revealing another batch.
 - Best-effort suppression of suggested and promoted surfaces.
-- Media autoplay prevention.
+- Media autoplay prevention that still allows deliberate playback.
 - Per-network enable or disable controls.
 - Firefox and Chromium production builds.
 

--- a/lib/feed-limiter.ts
+++ b/lib/feed-limiter.ts
@@ -5,6 +5,7 @@ import {
 } from "./platforms";
 import { BatchGateUi } from "./batch-gate-ui";
 import { planFeedVisibility } from "./feed-boundary";
+import { MediaAutoplayGuard } from "./media-autoplay";
 import { reserveAllowance } from "./storage";
 import type { Settings } from "./models";
 
@@ -25,6 +26,7 @@ export class FeedLimiter {
   private readonly revealedPostKeys = new Set<string>();
   private readonly fallbackPostKeys = new WeakMap<HTMLElement, string>();
   private readonly gate = new BatchGateUi();
+  private readonly mediaAutoplay = new MediaAutoplayGuard();
   private readonly mutationObserver: MutationObserver;
   private processingTimer?: number;
   private nextFallbackPostKey = 1;
@@ -76,8 +78,7 @@ export class FeedLimiter {
 
     if (this.settings.disableAutoplay) {
       document.querySelectorAll<HTMLMediaElement>("video, audio").forEach((media) => {
-        media.autoplay = false;
-        media.pause();
+        this.mediaAutoplay.prevent(media);
       });
     }
 

--- a/lib/media-autoplay.ts
+++ b/lib/media-autoplay.ts
@@ -1,0 +1,11 @@
+export class MediaAutoplayGuard {
+  private readonly stoppedMedia = new WeakSet<HTMLMediaElement>();
+
+  prevent(media: HTMLMediaElement): void {
+    media.autoplay = false;
+    if (this.stoppedMedia.has(media)) return;
+
+    this.stoppedMedia.add(media);
+    media.pause();
+  }
+}

--- a/tests/media-autoplay.test.ts
+++ b/tests/media-autoplay.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+import { MediaAutoplayGuard } from "../lib/media-autoplay";
+
+function createMedia(): {
+  media: HTMLMediaElement;
+  pause: ReturnType<typeof vi.fn>;
+} {
+  const pause = vi.fn();
+  return {
+    media: { autoplay: true, pause } as unknown as HTMLMediaElement,
+    pause,
+  };
+}
+
+describe("media autoplay guard", () => {
+  it("stops each media element only once so manual playback can continue", () => {
+    const guard = new MediaAutoplayGuard();
+    const { media, pause } = createMedia();
+
+    guard.prevent(media);
+    media.autoplay = true;
+    guard.prevent(media);
+
+    expect(media.autoplay).toBe(false);
+    expect(pause).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops newly discovered media independently", () => {
+    const guard = new MediaAutoplayGuard();
+    const first = createMedia();
+    const second = createMedia();
+
+    guard.prevent(first.media);
+    guard.prevent(second.media);
+
+    expect(first.pause).toHaveBeenCalledTimes(1);
+    expect(second.pause).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## What changed?

Autoplay prevention now pauses each newly discovered video or audio element only once. Later feed scans still clear the element's autoplay flag, but they no longer call `pause()` again, so deliberate playback can continue.

A focused `MediaAutoplayGuard` and unit coverage were added, and the documented behavior now makes clear that manual playback remains available.

## Why?

On Instagram's main feed, `FeedLimiter.process()` runs again whenever the feed's `MutationObserver` detects DOM changes. With “Stop autoplay” enabled, every run called `pause()` on every video. Pressing Play caused further Instagram mutations, which triggered another scan and immediately paused the video again.

The setting should stop automatic playback, not prevent the user from playing a video intentionally.

## How was it tested?

- [x] `npm run validate` — typecheck, 52 unit/integration tests, Firefox build and Chromium build
- [x] Unit test: repeated scans call `pause()` only once per media element
- [x] Unit test: newly discovered media elements are still stopped independently
- [ ] Instagram main-feed smoke test
- [ ] Firefox smoke test
- [ ] Chromium smoke test
- [ ] Firefox for Android smoke test

## Contribution checklist

- [x] The PR has one clear purpose and its title follows Conventional Commits.
- [x] The PR targets `main`; it is independent of PR #44.
- [x] I added tests for the regression.
- [x] I documented the user-visible behavior.
- [x] I did not add analytics, remote data collection or new permissions.
- [x] Platform selectors and route boundaries are unchanged.
- [ ] I included a recording of the Instagram behavior.

## Notes for reviewers

The guard uses a `WeakSet`, so media elements are not retained after Instagram removes them from the DOM. Manual verification on an authenticated Instagram feed remains outstanding.