### PR TITLE
feat: configure time limits per network

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,12 @@ Post counters and time budgets are independent per network:
   totals derived from their per-platform records.
 - `DailyUsageState.usedSecondsByPlatform` enforces an independent time ceiling
   for each network.
-- The effective time ceiling is captured when the day's state is created.
-  Changing the setting applies on the next local calendar day.
+- `Settings.sessionDurationMinutesByPlatform` and
+  `Settings.dailyUsageLimitMinutesByPlatform` configure the two time values
+  independently for each network.
+- `DailyUsageState.dailyLimitMinutesByPlatform` captures each effective time
+  ceiling when the day's state is created. Changing a setting applies on the
+  next local calendar day.
 
 Post batches can be unlocked repeatedly. Each unlock still requires the
 configured inline delay and press-and-hold interaction.

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -35,8 +35,8 @@ Keep the useful parts of social networks while giving every feed a real end.
   before another session is planned.
 - Session duration changes use discrete buttons instead of a slider, so adding
   more time requires a separate deliberate press for each step.
-- The configured default is 10 minutes and can be adjusted from 1 to 60
-  minutes at entry.
+- Each network has its own configured session suggestion. The default is 10
+  minutes per network and can be adjusted from 1 to 60 minutes at entry.
 - A compact floating counter shows the planned session time and the remaining
   daily time for the current network. Once a session starts, the counter and
   the chosen block survive same-network SPA navigation and browser history
@@ -47,9 +47,10 @@ Keep the useful parts of social networks while giving every feed a real end.
   that pause has completed.
 - Leaving an intervention replaces the current social-feed tab with a blank
   tab instead of relying on browser history.
-- A separate daily limit applies to each supported network. It persists across
-  reloads and sessions, resets on the next local calendar day and has no
-  in-page unlock.
+- A separately configurable daily limit applies to each supported network. It
+  persists across reloads and sessions, resets on the next local calendar day
+  and has no in-page unlock. Changes to a network's daily limit take effect on
+  the next local day.
 - Daily post counters and time mutations are serialized by the extension
   background context, and active tabs reconcile against persisted time usage
   from other tabs.

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ hold before the next finite batch is revealed.
 - Configurable delay before entering a supported feed.
 - Immediate interaction guard while local settings and the opening
   intervention load, preventing clicks or scrolling through the feed first.
-- Intentional session duration, adjusted through deliberate button steps, with
-  a floating countdown that remains active across same-network SPA and history
-  navigation.
+- Per-network intentional session duration, adjusted through deliberate button
+  steps, with a floating countdown that remains active across same-network SPA
+  and history navigation.
 - Optional Following-only modes for X and Instagram that select Following and
 - Intentional search on X, Instagram and Reddit: autocomplete or default
   recommendations are suppressed, X and Instagram Explore stay empty until a
@@ -76,7 +76,7 @@ hold before the next finite batch is revealed.
 - Optional YouTube Subscriptions-only mode redirects Home to Subscriptions and
   hides Home. Next-video and recommendation surfaces around requested videos
   are always hidden.
-- Non-extendable daily time ceiling for each network.
+- Separately configurable, non-extendable daily time ceiling for each network.
 - Finite initial and additional post batches with unlimited successive unlocks.
 - Stable per-session post counting for virtualized feeds such as Reddit.
 - Optional delay and press-and-hold step before revealing another batch.

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -226,7 +226,8 @@ export default defineContentScript({
       const opening = intervention.showOpening({
         platformLabel: adapter.label,
         delaySeconds: settings.openingDelaySeconds,
-        defaultSessionMinutes: settings.sessionDurationMinutes,
+        defaultSessionMinutes:
+          settings.sessionDurationMinutesByPlatform[adapter.id],
         availableSeconds,
         usageMetrics: [
           { label: "Reddit", usedSeconds: todayUsage.reddit },
@@ -264,7 +265,8 @@ export default defineContentScript({
           void (async () => {
             const extensionSeconds = await intervention.showSessionEnded({
               platformLabel: adapter.label,
-              defaultSessionMinutes: settings.sessionDurationMinutes,
+              defaultSessionMinutes:
+                settings.sessionDurationMinutesByPlatform[adapter.id],
               availableSeconds: remainingSeconds,
             });
             if (usageSession !== session) {

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -35,37 +35,75 @@
           <div class="section-heading">
             <h2>Intentional time</h2>
             <p>
-              Choose an intention for each session and a daily ceiling that
-              cannot be unlocked.
+              Tune the session intention and hard daily ceiling separately for
+              each network.
             </p>
           </div>
 
-          <div class="number-grid number-grid--two">
-            <label class="number-field">
-              <span>Suggested session</span>
-              <input
-                id="session-duration"
-                name="sessionDurationMinutes"
-                type="number"
-                min="1"
-                max="60"
-                step="1"
-              />
-              <small>minutes, adjustable when entering</small>
-            </label>
+          <div class="network-time-grid">
+            <fieldset class="network-time-card">
+              <legend>Reddit</legend>
+              <div class="network-time-fields">
+                <label class="number-field">
+                  <span>Suggested session</span>
+                  <input id="reddit-session-duration" name="redditSessionDurationMinutes" type="number" min="1" max="60" step="1" />
+                  <small>minutes</small>
+                </label>
+                <label class="number-field">
+                  <span>Daily maximum</span>
+                  <input id="reddit-daily-usage-limit" name="redditDailyUsageLimitMinutes" type="number" min="5" max="240" step="5" />
+                  <small>minutes, fixed until tomorrow</small>
+                </label>
+              </div>
+            </fieldset>
 
-            <label class="number-field">
-              <span>Daily maximum per network</span>
-              <input
-                id="daily-usage-limit"
-                name="dailyUsageLimitMinutes"
-                type="number"
-                min="5"
-                max="240"
-                step="5"
-              />
-              <small>minutes, fixed until tomorrow</small>
-            </label>
+            <fieldset class="network-time-card">
+              <legend>X / Twitter</legend>
+              <div class="network-time-fields">
+                <label class="number-field">
+                  <span>Suggested session</span>
+                  <input id="x-session-duration" name="xSessionDurationMinutes" type="number" min="1" max="60" step="1" />
+                  <small>minutes</small>
+                </label>
+                <label class="number-field">
+                  <span>Daily maximum</span>
+                  <input id="x-daily-usage-limit" name="xDailyUsageLimitMinutes" type="number" min="5" max="240" step="5" />
+                  <small>minutes, fixed until tomorrow</small>
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="network-time-card">
+              <legend>Instagram</legend>
+              <div class="network-time-fields">
+                <label class="number-field">
+                  <span>Suggested session</span>
+                  <input id="instagram-session-duration" name="instagramSessionDurationMinutes" type="number" min="1" max="60" step="1" />
+                  <small>minutes</small>
+                </label>
+                <label class="number-field">
+                  <span>Daily maximum</span>
+                  <input id="instagram-daily-usage-limit" name="instagramDailyUsageLimitMinutes" type="number" min="5" max="240" step="5" />
+                  <small>minutes, fixed until tomorrow</small>
+                </label>
+              </div>
+            </fieldset>
+
+            <fieldset class="network-time-card">
+              <legend>YouTube</legend>
+              <div class="network-time-fields">
+                <label class="number-field">
+                  <span>Suggested session</span>
+                  <input id="youtube-session-duration" name="youtubeSessionDurationMinutes" type="number" min="1" max="60" step="1" />
+                  <small>minutes</small>
+                </label>
+                <label class="number-field">
+                  <span>Daily maximum</span>
+                  <input id="youtube-daily-usage-limit" name="youtubeDailyUsageLimitMinutes" type="number" min="5" max="240" step="5" />
+                  <small>minutes, fixed until tomorrow</small>
+                </label>
+              </div>
+            </fieldset>
           </div>
         </section>
 

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -2,6 +2,7 @@ import "./style.css";
 import {
   DEFAULT_SETTINGS,
   sanitizeSettings,
+  type PlatformId,
   type Settings,
 } from "../../lib/models";
 import {
@@ -18,8 +19,6 @@ const controls = {
   openingDelayOutput: requiredElement<HTMLOutputElement>(
     "#opening-delay-output",
   ),
-  sessionDuration: requiredElement<HTMLInputElement>("#session-duration"),
-  dailyUsageLimit: requiredElement<HTMLInputElement>("#daily-usage-limit"),
   unlockDelay: requiredElement<HTMLInputElement>("#unlock-delay"),
   unlockDelayOutput:
     requiredElement<HTMLOutputElement>("#unlock-delay-output"),
@@ -43,6 +42,28 @@ const controls = {
   disableAutoplay: requiredElement<HTMLInputElement>("#disable-autoplay"),
 };
 
+const timeControls: Record<
+  PlatformId,
+  { sessionDuration: HTMLInputElement; dailyUsageLimit: HTMLInputElement }
+> = {
+  reddit: {
+    sessionDuration: requiredElement("#reddit-session-duration"),
+    dailyUsageLimit: requiredElement("#reddit-daily-usage-limit"),
+  },
+  x: {
+    sessionDuration: requiredElement("#x-session-duration"),
+    dailyUsageLimit: requiredElement("#x-daily-usage-limit"),
+  },
+  instagram: {
+    sessionDuration: requiredElement("#instagram-session-duration"),
+    dailyUsageLimit: requiredElement("#instagram-daily-usage-limit"),
+  },
+  youtube: {
+    sessionDuration: requiredElement("#youtube-session-duration"),
+    dailyUsageLimit: requiredElement("#youtube-daily-usage-limit"),
+  },
+};
+
 function requiredElement<T extends Element>(selector: string): T {
   const element = document.querySelector<T>(selector);
   if (!element) throw new Error(`Missing options element: ${selector}`);
@@ -58,8 +79,14 @@ function updateOutputs(): void {
 function render(settings: Settings): void {
   controls.enabled.checked = settings.enabled;
   controls.openingDelay.value = String(settings.openingDelaySeconds);
-  controls.sessionDuration.value = String(settings.sessionDurationMinutes);
-  controls.dailyUsageLimit.value = String(settings.dailyUsageLimitMinutes);
+  for (const platform of Object.keys(timeControls) as PlatformId[]) {
+    timeControls[platform].sessionDuration.value = String(
+      settings.sessionDurationMinutesByPlatform[platform],
+    );
+    timeControls[platform].dailyUsageLimit.value = String(
+      settings.dailyUsageLimitMinutesByPlatform[platform],
+    );
+  }
   controls.unlockDelay.value = String(settings.unlockDelaySeconds);
   controls.batchSize.value = String(settings.batchSize);
   controls.unlockBatchSize.value = String(settings.unlockBatchSize);
@@ -80,8 +107,18 @@ function readSettings(): Settings {
   return sanitizeSettings({
     enabled: controls.enabled.checked,
     openingDelaySeconds: Number(controls.openingDelay.value),
-    sessionDurationMinutes: Number(controls.sessionDuration.value),
-    dailyUsageLimitMinutes: Number(controls.dailyUsageLimit.value),
+    sessionDurationMinutesByPlatform: {
+      reddit: Number(timeControls.reddit.sessionDuration.value),
+      x: Number(timeControls.x.sessionDuration.value),
+      instagram: Number(timeControls.instagram.sessionDuration.value),
+      youtube: Number(timeControls.youtube.sessionDuration.value),
+    },
+    dailyUsageLimitMinutesByPlatform: {
+      reddit: Number(timeControls.reddit.dailyUsageLimit.value),
+      x: Number(timeControls.x.dailyUsageLimit.value),
+      instagram: Number(timeControls.instagram.dailyUsageLimit.value),
+      youtube: Number(timeControls.youtube.dailyUsageLimit.value),
+    },
     unlockDelaySeconds: Number(controls.unlockDelay.value),
     batchSize: Number(controls.batchSize.value),
     unlockBatchSize: Number(controls.unlockBatchSize.value),

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -118,6 +118,7 @@ input {
 
 .field,
 .number-grid,
+.network-time-grid,
 .toggle-list {
   grid-column: 2;
 }
@@ -144,6 +145,35 @@ input {
 .number-grid {
   display: grid;
   gap: 10px;
+}
+
+.network-time-grid {
+  display: grid;
+  gap: 14px;
+}
+
+.network-time-card {
+  min-width: 0;
+  margin: 0;
+  padding: 16px;
+  border: 1px solid var(--line);
+}
+
+.network-time-card legend {
+  padding: 0 8px;
+  font-family: "Iowan Old Style", "Palatino Linotype", serif;
+  font-size: 24px;
+}
+
+.network-time-fields {
+  display: grid;
+  gap: 10px;
+}
+
+.network-time-card .number-field {
+  padding: 12px 0;
+  border: 0;
+  border-top: 1px solid var(--line);
 }
 
 .number-field {
@@ -279,6 +309,10 @@ input {
 
   .number-grid--two {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .network-time-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .number-field {

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -1,10 +1,12 @@
 export type PlatformId = "reddit" | "x" | "instagram" | "youtube";
 
+export type PlatformMinutes = Record<PlatformId, number>;
+
 export interface Settings {
   enabled: boolean;
   openingDelaySeconds: number;
-  sessionDurationMinutes: number;
-  dailyUsageLimitMinutes: number;
+  sessionDurationMinutesByPlatform: PlatformMinutes;
+  dailyUsageLimitMinutesByPlatform: PlatformMinutes;
   batchSize: number;
   unlockBatchSize: number;
   unlockDelaySeconds: number;
@@ -27,15 +29,25 @@ export interface DailyState {
 
 export interface DailyUsageState {
   date: string;
-  dailyLimitMinutes: number;
+  dailyLimitMinutesByPlatform: PlatformMinutes;
   usedSecondsByPlatform: Record<PlatformId, number>;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
   enabled: true,
   openingDelaySeconds: 5,
-  sessionDurationMinutes: 10,
-  dailyUsageLimitMinutes: 30,
+  sessionDurationMinutesByPlatform: {
+    reddit: 10,
+    x: 10,
+    instagram: 10,
+    youtube: 10,
+  },
+  dailyUsageLimitMinutesByPlatform: {
+    reddit: 30,
+    x: 30,
+    instagram: 30,
+    youtube: 30,
+  },
   batchSize: 20,
   unlockBatchSize: 10,
   unlockDelaySeconds: 5,
@@ -53,44 +65,83 @@ export const DEFAULT_SETTINGS: Settings = {
   },
 };
 
-const clampInteger = (value: number, minimum: number, maximum: number) =>
-  Math.min(maximum, Math.max(minimum, Math.round(value)));
+type SettingsInput = Partial<
+  Omit<
+    Settings,
+    "sessionDurationMinutesByPlatform" | "dailyUsageLimitMinutesByPlatform"
+  >
+> & {
+  sessionDurationMinutesByPlatform?: Partial<PlatformMinutes>;
+  dailyUsageLimitMinutesByPlatform?: Partial<PlatformMinutes>;
+  sessionDurationMinutes?: number;
+  dailyUsageLimitMinutes?: number;
+};
 
-export function sanitizeSettings(input: Partial<Settings>): Settings {
+function clampInteger(
+  value: number | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(maximum, Math.max(minimum, Math.round(value ?? fallback)));
+}
+
+export function sanitizeSettings(input: SettingsInput): Settings {
+  const legacySessionDuration = clampInteger(
+    input.sessionDurationMinutes,
+    DEFAULT_SETTINGS.sessionDurationMinutesByPlatform.reddit,
+    1,
+    60,
+  );
+  const legacyDailyLimit = clampInteger(
+    input.dailyUsageLimitMinutes,
+    DEFAULT_SETTINGS.dailyUsageLimitMinutesByPlatform.reddit,
+    5,
+    240,
+  );
+
   return {
     enabled: sanitizeBoolean(input.enabled, DEFAULT_SETTINGS.enabled),
     openingDelaySeconds: clampInteger(
-      input.openingDelaySeconds ?? DEFAULT_SETTINGS.openingDelaySeconds,
+      input.openingDelaySeconds,
+      DEFAULT_SETTINGS.openingDelaySeconds,
       0,
       60,
     ),
-    sessionDurationMinutes: clampInteger(
-      input.sessionDurationMinutes ?? DEFAULT_SETTINGS.sessionDurationMinutes,
+    sessionDurationMinutesByPlatform: sanitizePlatformMinutes(
+      input.sessionDurationMinutesByPlatform,
+      legacySessionDuration,
       1,
       60,
     ),
-    dailyUsageLimitMinutes: clampInteger(
-      input.dailyUsageLimitMinutes ?? DEFAULT_SETTINGS.dailyUsageLimitMinutes,
+    dailyUsageLimitMinutesByPlatform: sanitizePlatformMinutes(
+      input.dailyUsageLimitMinutesByPlatform,
+      legacyDailyLimit,
       5,
       240,
     ),
     batchSize: clampInteger(
-      input.batchSize ?? DEFAULT_SETTINGS.batchSize,
+      input.batchSize,
+      DEFAULT_SETTINGS.batchSize,
       5,
       100,
     ),
     unlockBatchSize: clampInteger(
-      input.unlockBatchSize ?? DEFAULT_SETTINGS.unlockBatchSize,
+      input.unlockBatchSize,
+      DEFAULT_SETTINGS.unlockBatchSize,
       5,
       50,
     ),
     unlockDelaySeconds: clampInteger(
-      input.unlockDelaySeconds ?? DEFAULT_SETTINGS.unlockDelaySeconds,
+      input.unlockDelaySeconds,
+      DEFAULT_SETTINGS.unlockDelaySeconds,
       0,
       60,
     ),
     holdSeconds: clampInteger(
-      input.holdSeconds ?? DEFAULT_SETTINGS.holdSeconds,
+      input.holdSeconds,
+      DEFAULT_SETTINGS.holdSeconds,
       1,
       10,
     ),
@@ -181,11 +232,16 @@ export function normalizeDailyState(
 
 export function emptyDailyUsageState(
   date = new Date(),
-  dailyLimitMinutes = 0,
+  dailyLimitMinutesByPlatform: PlatformMinutes = {
+    reddit: 0,
+    x: 0,
+    instagram: 0,
+    youtube: 0,
+  },
 ): DailyUsageState {
   return {
     date: localDateKey(date),
-    dailyLimitMinutes,
+    dailyLimitMinutesByPlatform: { ...dailyLimitMinutesByPlatform },
     usedSecondsByPlatform: {
       reddit: 0,
       x: 0,
@@ -197,24 +253,51 @@ export function emptyDailyUsageState(
 
 export function normalizeDailyUsageState(
   state:
-    | (Partial<Omit<DailyUsageState, "usedSecondsByPlatform">> & {
+    | (Partial<
+        Omit<
+          DailyUsageState,
+          "dailyLimitMinutesByPlatform" | "usedSecondsByPlatform"
+        >
+      > & {
+        dailyLimitMinutesByPlatform?: Partial<PlatformMinutes>;
+        dailyLimitMinutes?: number;
         usedSecondsByPlatform?: Partial<Record<PlatformId, number>>;
       })
     | null,
   date = new Date(),
-  configuredLimitMinutes = DEFAULT_SETTINGS.dailyUsageLimitMinutes,
+  configuredLimitMinutesByPlatform =
+    DEFAULT_SETTINGS.dailyUsageLimitMinutesByPlatform,
 ): DailyUsageState {
   if (state?.date !== localDateKey(date)) {
-    return emptyDailyUsageState(date, configuredLimitMinutes);
+    return emptyDailyUsageState(date, configuredLimitMinutesByPlatform);
   }
+
+  const legacyLimitMinutes = normalizeDailyLimit(state.dailyLimitMinutes);
 
   return {
     date: state.date,
-    dailyLimitMinutes:
-      typeof state.dailyLimitMinutes === "number" &&
-      state.dailyLimitMinutes >= 5
-        ? state.dailyLimitMinutes
-        : configuredLimitMinutes,
+    dailyLimitMinutesByPlatform: {
+      reddit: resolveDailyLimit(
+        state.dailyLimitMinutesByPlatform?.reddit,
+        legacyLimitMinutes,
+        configuredLimitMinutesByPlatform.reddit,
+      ),
+      x: resolveDailyLimit(
+        state.dailyLimitMinutesByPlatform?.x,
+        legacyLimitMinutes,
+        configuredLimitMinutesByPlatform.x,
+      ),
+      instagram: resolveDailyLimit(
+        state.dailyLimitMinutesByPlatform?.instagram,
+        legacyLimitMinutes,
+        configuredLimitMinutesByPlatform.instagram,
+      ),
+      youtube: resolveDailyLimit(
+        state.dailyLimitMinutesByPlatform?.youtube,
+        legacyLimitMinutes,
+        configuredLimitMinutesByPlatform.youtube,
+      ),
+    },
     usedSecondsByPlatform: normalizePlatformCounts(
       state.usedSecondsByPlatform,
     ),
@@ -227,13 +310,44 @@ export function availableUsageSeconds(
   platform: PlatformId,
 ): number {
   const effectiveLimitMinutes =
-    state.dailyLimitMinutes >= 5
-      ? state.dailyLimitMinutes
-      : settings.dailyUsageLimitMinutes;
+    normalizeDailyLimit(state.dailyLimitMinutesByPlatform[platform]) ??
+    settings.dailyUsageLimitMinutesByPlatform[platform];
   const dailyLimitSeconds = effectiveLimitMinutes * 60;
   return Math.max(
     0,
     dailyLimitSeconds - state.usedSecondsByPlatform[platform],
+  );
+}
+
+function sanitizePlatformMinutes(
+  values: Partial<PlatformMinutes> | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): PlatformMinutes {
+  return {
+    reddit: clampInteger(values?.reddit, fallback, minimum, maximum),
+    x: clampInteger(values?.x, fallback, minimum, maximum),
+    instagram: clampInteger(values?.instagram, fallback, minimum, maximum),
+    youtube: clampInteger(values?.youtube, fallback, minimum, maximum),
+  };
+}
+
+function normalizeDailyLimit(value: number | undefined): number | undefined {
+  if (!Number.isFinite(value) || (value ?? 0) < 5) return undefined;
+  return Math.min(240, Math.round(value ?? 0));
+}
+
+function resolveDailyLimit(
+  stored: number | undefined,
+  legacy: number | undefined,
+  configured: number,
+): number {
+  return (
+    normalizeDailyLimit(stored) ??
+    legacy ??
+    normalizeDailyLimit(configured) ??
+    DEFAULT_SETTINGS.dailyUsageLimitMinutesByPlatform.reddit
   );
 }
 

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -116,7 +116,7 @@ export async function getDailyUsageState(): Promise<DailyUsageState> {
   return normalizeDailyUsageState(
     await dailyUsageStateItem.getValue(),
     new Date(),
-    settings.dailyUsageLimitMinutes,
+    settings.dailyUsageLimitMinutesByPlatform,
   );
 }
 
@@ -156,9 +156,10 @@ export async function addUsageSecondsFromStorage(
   const current = normalizeDailyUsageState(
     stored,
     new Date(),
-    settings.dailyUsageLimitMinutes,
+    settings.dailyUsageLimitMinutesByPlatform,
   );
-  const dailyLimitSeconds = current.dailyLimitMinutes * 60;
+  const dailyLimitSeconds =
+    current.dailyLimitMinutesByPlatform[platform] * 60;
   const increment = Math.max(0, Math.round(elapsedSeconds));
   const usedSeconds = Math.min(
     dailyLimitSeconds,

--- a/tests/lifecycle.integration.test.ts
+++ b/tests/lifecycle.integration.test.ts
@@ -13,6 +13,7 @@ import {
 import {
   dailyStateItem,
   dailyUsageStateItem,
+  addUsageSeconds,
   getDailyUsageState,
   reserveAllowance,
   settingsItem,
@@ -85,7 +86,8 @@ const createUi = () =>
 
 const createSession = (
   lifecycle: FakeTabLifecycle,
-  availableSeconds = DEFAULT_SETTINGS.dailyUsageLimitMinutes * 60,
+  availableSeconds =
+    DEFAULT_SETTINGS.dailyUsageLimitMinutesByPlatform.reddit * 60,
 ) =>
   new UsageSession(
     {
@@ -113,7 +115,12 @@ describe("extension lifecycle integration", () => {
     );
     await settingsItem.setValue({
       ...DEFAULT_SETTINGS,
-      dailyUsageLimitMinutes: 5,
+      dailyUsageLimitMinutesByPlatform: {
+        reddit: 5,
+        x: 5,
+        instagram: 5,
+        youtube: 5,
+      },
     });
   });
 
@@ -163,6 +170,31 @@ describe("extension lifecycle integration", () => {
     ]);
     expect(postState.revealedByPlatform.reddit).toBe(80);
     expect(usageState.usedSecondsByPlatform.reddit).toBe(14);
+  });
+
+  it("enforces a different daily maximum for each network", async () => {
+    await settingsItem.setValue({
+      ...DEFAULT_SETTINGS,
+      dailyUsageLimitMinutesByPlatform: {
+        reddit: 5,
+        x: 10,
+        instagram: 15,
+        youtube: 20,
+      },
+    });
+
+    expect(await addUsageSeconds("reddit", 300)).toBe(0);
+    expect(await addUsageSeconds("x", 300)).toBe(300);
+
+    const usage = await getDailyUsageState();
+    expect(usage.dailyLimitMinutesByPlatform).toEqual({
+      reddit: 5,
+      x: 10,
+      instagram: 15,
+      youtube: 20,
+    });
+    expect(usage.usedSecondsByPlatform.reddit).toBe(300);
+    expect(usage.usedSecondsByPlatform.x).toBe(300);
   });
 
   it("flushes pending time on teardown and restores it after a reload", async () => {

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -14,8 +14,14 @@ describe("settings", () => {
   it("uses safe defaults and clamps numeric values", () => {
     const settings = sanitizeSettings({
       openingDelaySeconds: 900,
-      sessionDurationMinutes: 0,
-      dailyUsageLimitMinutes: 900,
+      sessionDurationMinutesByPlatform: {
+        ...DEFAULT_SETTINGS.sessionDurationMinutesByPlatform,
+        reddit: 0,
+      },
+      dailyUsageLimitMinutesByPlatform: {
+        ...DEFAULT_SETTINGS.dailyUsageLimitMinutesByPlatform,
+        instagram: 900,
+      },
       batchSize: 0,
       unlockBatchSize: 300,
       holdSeconds: 0,
@@ -29,8 +35,10 @@ describe("settings", () => {
     });
 
     expect(settings.openingDelaySeconds).toBe(60);
-    expect(settings.sessionDurationMinutes).toBe(1);
-    expect(settings.dailyUsageLimitMinutes).toBe(240);
+    expect(settings.sessionDurationMinutesByPlatform.reddit).toBe(1);
+    expect(settings.sessionDurationMinutesByPlatform.x).toBe(10);
+    expect(settings.dailyUsageLimitMinutesByPlatform.instagram).toBe(240);
+    expect(settings.dailyUsageLimitMinutesByPlatform.youtube).toBe(30);
     expect(settings.batchSize).toBe(5);
     expect(settings.unlockBatchSize).toBe(50);
     expect(settings.holdSeconds).toBe(1);
@@ -61,6 +69,28 @@ describe("settings", () => {
 
     expect(settings.youtubeSubscriptionsOnly).toBe(true);
     expect(settings.enabledSites.youtube).toBe(false);
+  });
+
+  it("migrates legacy global time settings to every network", () => {
+    const settings = sanitizeSettings({
+      sessionDurationMinutes: 12,
+      dailyUsageLimitMinutes: 45,
+    });
+
+    expect(settings.sessionDurationMinutesByPlatform).toEqual({
+      reddit: 12,
+      x: 12,
+      instagram: 12,
+      youtube: 12,
+    });
+    expect(settings.dailyUsageLimitMinutesByPlatform).toEqual({
+      reddit: 45,
+      x: 45,
+      instagram: 45,
+      youtube: 45,
+    });
+    expect(settings).not.toHaveProperty("sessionDurationMinutes");
+    expect(settings).not.toHaveProperty("dailyUsageLimitMinutes");
   });
 
   it("drops legacy post-limit and friction-mode settings", () => {
@@ -109,8 +139,14 @@ describe("daily state", () => {
   });
 
   it("resets stale time usage and calculates a per-network hard limit", () => {
+    const configuredLimits = {
+      reddit: 10,
+      x: 20,
+      instagram: 30,
+      youtube: 40,
+    };
     const staleUsage = {
-      ...emptyDailyUsageState(new Date(2026, 6, 28), 10),
+      ...emptyDailyUsageState(new Date(2026, 6, 28), configuredLimits),
       usedSecondsByPlatform: {
         reddit: 900,
         x: 0,
@@ -118,35 +154,66 @@ describe("daily state", () => {
         youtube: 0,
       },
     };
-    const currentUsage = normalizeDailyUsageState(staleUsage, today, 10);
+    const currentUsage = normalizeDailyUsageState(
+      staleUsage,
+      today,
+      configuredLimits,
+    );
 
-    expect(currentUsage).toEqual(emptyDailyUsageState(today, 10));
+    expect(currentUsage).toEqual(
+      emptyDailyUsageState(today, configuredLimits),
+    );
 
     currentUsage.usedSecondsByPlatform.reddit = 420;
     expect(
       availableUsageSeconds(
-        { ...DEFAULT_SETTINGS, dailyUsageLimitMinutes: 10 },
+        {
+          ...DEFAULT_SETTINGS,
+          dailyUsageLimitMinutesByPlatform: configuredLimits,
+        },
         currentUsage,
         "reddit",
       ),
     ).toBe(180);
     expect(
       availableUsageSeconds(
-        { ...DEFAULT_SETTINGS, dailyUsageLimitMinutes: 10 },
+        {
+          ...DEFAULT_SETTINGS,
+          dailyUsageLimitMinutesByPlatform: configuredLimits,
+        },
         currentUsage,
         "x",
       ),
-    ).toBe(600);
+    ).toBe(1200);
   });
 
-  it("keeps the effective time limit fixed until the next day", () => {
-    const usage = emptyDailyUsageState(today, 20);
-    const normalized = normalizeDailyUsageState(usage, today, 60);
+  it("keeps each effective time limit fixed until the next day", () => {
+    const storedLimits = {
+      reddit: 20,
+      x: 25,
+      instagram: 30,
+      youtube: 35,
+    };
+    const configuredLimits = {
+      reddit: 60,
+      x: 65,
+      instagram: 70,
+      youtube: 75,
+    };
+    const usage = emptyDailyUsageState(today, storedLimits);
+    const normalized = normalizeDailyUsageState(
+      usage,
+      today,
+      configuredLimits,
+    );
 
-    expect(normalized.dailyLimitMinutes).toBe(20);
+    expect(normalized.dailyLimitMinutesByPlatform).toEqual(storedLimits);
     expect(
       availableUsageSeconds(
-        { ...DEFAULT_SETTINGS, dailyUsageLimitMinutes: 60 },
+        {
+          ...DEFAULT_SETTINGS,
+          dailyUsageLimitMinutesByPlatform: configuredLimits,
+        },
         normalized,
         "reddit",
       ),
@@ -160,8 +227,20 @@ describe("daily state", () => {
       usedSecondsByPlatform: { reddit: 60, x: 0, instagram: 0 },
     };
 
-    expect(normalizeDailyUsageState(legacy, today, 30)).toEqual({
-      ...legacy,
+    expect(
+      normalizeDailyUsageState(
+        legacy,
+        today,
+        DEFAULT_SETTINGS.dailyUsageLimitMinutesByPlatform,
+      ),
+    ).toEqual({
+      date: legacy.date,
+      dailyLimitMinutesByPlatform: {
+        reddit: 30,
+        x: 30,
+        instagram: 30,
+        youtube: 30,
+      },
       usedSecondsByPlatform: {
         ...legacy.usedSecondsByPlatform,
         youtube: 0,

--- a/tests/usage-history.test.ts
+++ b/tests/usage-history.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { emptyDailyUsageState } from "../lib/models";
+import { DEFAULT_SETTINGS, emptyDailyUsageState } from "../lib/models";
 import {
   USAGE_HISTORY_RETENTION_DAYS,
   normalizeUsageHistory,
@@ -67,9 +67,15 @@ describe("usage history", () => {
   });
 
   it("records a current snapshot without discarding previous days", () => {
-    const previous = emptyDailyUsageState(new Date(2026, 7, 2), 30);
+    const previous = emptyDailyUsageState(
+      new Date(2026, 7, 2),
+      DEFAULT_SETTINGS.dailyUsageLimitMinutesByPlatform,
+    );
     previous.usedSecondsByPlatform.reddit = 300;
-    const current = emptyDailyUsageState(new Date(2026, 7, 3), 30);
+    const current = emptyDailyUsageState(
+      new Date(2026, 7, 3),
+      DEFAULT_SETTINGS.dailyUsageLimitMinutesByPlatform,
+    );
     current.usedSecondsByPlatform.instagram = 125;
 
     const history = recordUsageState(
@@ -88,7 +94,10 @@ describe("usage history", () => {
   });
 
   it("never lowers an already persisted cumulative counter", () => {
-    const state = emptyDailyUsageState(new Date(2026, 7, 3), 30);
+    const state = emptyDailyUsageState(
+      new Date(2026, 7, 3),
+      DEFAULT_SETTINGS.dailyUsageLimitMinutesByPlatform,
+    );
     state.usedSecondsByPlatform.reddit = 60;
     const history = recordUsageState(
       {


### PR DESCRIPTION
## What changed?

- Adds separate suggested-session and daily-maximum settings for Reddit, X, Instagram and YouTube.
- Uses the current network's suggested duration in the opening and session-extension interventions.
- Captures and enforces each network's daily hard limit independently until the next local day.
- Migrates legacy global time settings and current-day usage state without changing existing users' effective values.
- Updates the options UI, product documentation and automated coverage.

## Why?

Different networks invite different usage patterns. A single suggested session and daily maximum cannot express a short Instagram budget alongside a longer YouTube or Reddit budget.

## How was it tested?

- `npm run validate` (typecheck, 54 tests, Firefox build and Chromium build)
- `npm run zip` (Firefox and Chromium production packages)
- Added model coverage for legacy settings/state migration and per-network calculations.
- Added an integration test proving different hard limits are enforced for Reddit and X.

- [x] `npm run validate`
- [ ] Firefox
- [ ] Chromium
- [ ] Firefox for Android

## Contribution checklist

- [x] The PR has one clear purpose and its title follows Conventional Commits.
- [x] The PR targets `main`; dependencies on other open PRs and their merge order are documented above.
- [x] I added or updated tests for behavior that can be tested automatically.
- [x] I documented user-facing settings or behavior changes.
- [x] I did not add analytics, remote data collection or new permissions without explaining why and documenting the privacy impact.
- [x] I checked that selectors fail safely if a social network changes its DOM.
- [ ] I included screenshots or a short recording for visible interface changes.

## Notes for reviewers

The PR is independent and targets the current `main` at v0.6.0. No permissions, host matches, selectors or remote data behavior change. Manual browser/device smoke testing and an updated options screenshot remain for review.