### PR TITLE
feat: schedule limits by network

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,14 +66,16 @@ On a supported feed route, the content script:
 1. Loads sanitized settings and the current local-day usage state.
 2. Stops immediately when the extension/site is disabled or the route is not a
    feed.
-3. Blocks entry when the per-network daily time ceiling is exhausted.
-4. Shows a configurable opening delay and asks for an intended session length.
-5. Starts the finite-feed limiter with the configured initial batch.
-6. Counts time only while the document is visible and shows a floating timer.
-7. Stops at the selected session duration and asks the user to leave or choose
+3. Resolves the network's global, custom or always-active weekly schedule and
+   bypasses feed/time limits outside its active window.
+4. Blocks entry when the per-network daily time ceiling is exhausted.
+5. Shows a configurable opening delay and asks for an intended session length.
+6. Starts the finite-feed limiter with the configured initial batch.
+7. Counts time only while the document is visible and shows a floating timer.
+8. Stops at the selected session duration and asks the user to leave or choose
    another block.
-8. Enforces the daily time ceiling without an in-page extension or reset.
-9. Shows an end-of-batch intervention before revealing more posts.
+9. Enforces the daily time ceiling without an in-page extension or reset.
+10. Shows an end-of-batch intervention before revealing more posts.
 
 Post counters and time budgets are independent per network:
 
@@ -89,6 +91,9 @@ Post counters and time budgets are independent per network:
 - `DailyUsageState.dailyLimitMinutesByPlatform` captures each effective time
   ceiling when the day's state is created. Changing a setting applies on the
   next local calendar day.
+- `Settings.limitSchedule` stores the optional global weekly window plus each
+  platform's global, custom or always-active mode. Schedule changes apply on
+  reactivation, and clock boundaries are detected by the content lifecycle.
 
 Post batches can be unlocked repeatedly. Each unlock still requires the
 configured inline delay and press-and-hold interaction.
@@ -211,6 +216,8 @@ Preserve these invariants:
 
 - Calendar resets use the user's local date, not UTC.
 - Numeric settings are finite integers constrained to product-safe ranges.
+- Schedule times use validated local `HH:MM` values; overnight windows inherit
+  the selected start day and continue into the following morning.
 - Usage is counted only while the supported feed document is visible.
 - Pending seconds are persisted on visibility loss, page hide and teardown.
 - A time-limit change cannot increase the effective ceiling for the current

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -60,6 +60,25 @@ Keep the useful parts of social networks while giving every feed a real end.
 - The effective ceiling is fixed for the day. Configuration changes apply on
   the next local calendar day, and the settings page cannot reset elapsed time.
 
+## Limit schedules
+
+- Scheduling is optional. With the global schedule disabled, inherited limits
+  remain active all day as in earlier versions.
+- The global schedule defines active weekdays plus a local start and end time.
+- Each network can inherit the global schedule, use its own weekdays and time
+  window, or keep limits always active.
+- Start times are inclusive and end times are exclusive. A window whose end is
+  earlier than its start continues overnight into the following day; equal
+  times mean the full selected day.
+- Crossing a schedule boundary starts or stops feed limits without requiring a
+  reload. Ending a window flushes any pending usage time before removing the
+  active session and batch limiter.
+- Outside an active window, opening/session interventions, time accounting and
+  finite feed batches are inactive for that network. Suggestion suppression and
+  preferred-feed settings remain enabled.
+- Schedules use the browser's local clock and are stored only in extension
+  local storage.
+
 ## Unlock flow
 
 The end of a batch is rendered inside the native feed. The inline control waits

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ available while adding deliberate friction around habitual scrolling:
 5. Posts are revealed in finite batches instead of an endless stream.
 6. Reaching the end shows an inline control for loading the next batch.
 7. A per-network daily time ceiling cannot be extended from the page.
+8. Weekly schedules decide when those limits are active, globally or per
+   network.
 
 Daily post counts and time ceilings are tracked independently for Reddit,
 X/Twitter, Instagram, and YouTube. Post counts do not impose a maximum: every
@@ -63,7 +65,8 @@ hold before the next finite batch is revealed.
 - Per-network intentional session duration, adjusted through deliberate button
   steps, with a floating countdown that remains active across same-network SPA
   and history navigation.
-- Optional Following-only modes for X and Instagram that select Following and
+- Optional Following-only modes for X and Instagram that select followed
+  content while keeping direct profiles available.
 - Intentional search on X, Instagram and Reddit: autocomplete or default
   recommendations are suppressed, X and Instagram Explore stay empty until a
   deliberate query, and X result tabs plus Reddit's Popular, News and Explore
@@ -77,6 +80,8 @@ hold before the next finite batch is revealed.
   hides Home. Next-video and recommendation surfaces around requested videos
   are always hidden.
 - Separately configurable, non-extendable daily time ceiling for each network.
+- Optional weekly limit schedule with a global default and per-network custom
+  hours, days or always-active override.
 - Finite initial and additional post batches with unlimited successive unlocks.
 - Stable per-session post counting for virtualized feeds such as Reddit.
 - Optional delay and press-and-hold step before revealing another batch.
@@ -87,12 +92,12 @@ hold before the next finite batch is revealed.
 
 ## Supported networks
 
-| Network | Feed limiting | Suggested-content suppression | Daily time ceiling |
-| --- | --- | --- | --- |
-| Reddit | Yes | Best effort | Independent |
-| X / Twitter | Yes | Best effort | Independent |
-| Instagram | Yes | Best effort | Independent |
-| YouTube | Yes | Best effort | Independent |
+| Network | Feed limiting | Suggested-content suppression | Daily time ceiling | Schedule |
+| --- | --- | --- | --- | --- |
+| Reddit | Yes | Best effort | Independent | Global or custom |
+| X / Twitter | Yes | Best effort | Independent | Global or custom |
+| Instagram | Yes | Best effort | Independent | Global or custom |
+| YouTube | Yes | Best effort | Independent | Global or custom |
 
 The limiter applies only to recognized feed routes. Direct profiles, messages,
 settings, and individual post pages are intended to remain available. Platform
@@ -158,6 +163,7 @@ lib/
   ├─ platforms.ts
   ├─ feed-limiter.ts
   ├─ usage-session.ts
+  ├─ limit-schedule.ts
   ├─ usage-history.ts
   ├─ intervention-ui.ts
   └─ session-time.ts

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -2,7 +2,12 @@ import "../assets/content.css";
 import { FeedLimiter } from "../lib/feed-limiter";
 import { InterventionUi } from "../lib/intervention-ui";
 import { IntentionalSearchController } from "../lib/intentional-search";
-import { availableUsageSeconds, localDateKey } from "../lib/models";
+import { areLimitsActive } from "../lib/limit-schedule";
+import {
+  availableUsageSeconds,
+  localDateKey,
+  type Settings,
+} from "../lib/models";
 import { PageInteractionGuard } from "../lib/page-interaction-guard";
 import { getPlatformAdapter } from "../lib/platforms";
 import { PreferredFeedController } from "../lib/preferred-feed";
@@ -93,9 +98,13 @@ export default defineContentScript({
     let sessionPostAllowance = 0;
     let currentUrl = "";
     let activationId = 0;
+    let currentSettings: Settings | undefined;
+    let limitsAreActive: boolean | undefined;
 
     const activate = (preserveUsageSession = false): Promise<void> => {
       const thisActivation = ++activationId;
+      currentSettings = undefined;
+      limitsAreActive = undefined;
       const url = new URL(location.href);
       if (
         adapter.isFeedRoute(url) &&
@@ -129,6 +138,7 @@ export default defineContentScript({
 
       const settings = await getSettings();
       if (thisActivation !== activationId) return;
+      currentSettings = settings;
       if (!settings.enabled || !settings.enabledSites[adapter.id]) {
         return;
       }
@@ -195,6 +205,17 @@ export default defineContentScript({
         }
         preferredFeed = new PreferredFeedController(adapter);
         preferredFeed.start();
+      }
+
+      limitsAreActive = areLimitsActive(settings, adapter.id);
+      if (!limitsAreActive) {
+        const previousUsageSession = usageSession;
+        usageSession = undefined;
+        sessionPostAllowance = 0;
+        await previousUsageSession?.destroy();
+        if (thisActivation !== activationId) return;
+        intervention.hideAll();
+        return;
       }
 
       if (usageSession) {
@@ -295,9 +316,17 @@ export default defineContentScript({
     void activate();
 
     const navigationTimer = window.setInterval(() => {
-      if (location.href === currentUrl) return;
-      currentUrl = location.href;
-      void activate(true);
+      if (location.href !== currentUrl) {
+        currentUrl = location.href;
+        void activate(true);
+        return;
+      }
+      if (!currentSettings || limitsAreActive === undefined) return;
+      const nextLimitsAreActive = areLimitsActive(
+        currentSettings,
+        adapter.id,
+      );
+      if (nextLimitsAreActive !== limitsAreActive) void activate();
     }, 600);
 
     const unwatchSettings = settingsItem.watch(() => {

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -33,82 +33,174 @@
         <section class="panel">
           <div class="section-number">01</div>
           <div class="section-heading">
-            <h2>Intentional time</h2>
+            <h2>Global schedule</h2>
             <p>
-              Tune the session intention and hard daily ceiling separately for
-              each network.
+              Choose when limits are active by default. Networks can inherit
+              this schedule or override it below.
             </p>
           </div>
 
-          <div class="network-time-grid">
-            <fieldset class="network-time-card">
-              <legend>Reddit</legend>
-              <div class="network-time-fields">
-                <label class="number-field">
-                  <span>Suggested session</span>
-                  <input id="reddit-session-duration" name="redditSessionDurationMinutes" type="number" min="1" max="60" step="1" />
-                  <small>minutes</small>
+          <div class="schedule-card">
+            <label class="schedule-toggle">
+              <span>
+                <strong>Use a global schedule</strong>
+                <small>When off, inherited limits stay active all day.</small>
+              </span>
+              <input id="global-schedule-enabled" type="checkbox" />
+            </label>
+            <div id="global-schedule-fields" class="schedule-fields">
+              <div class="time-range">
+                <label>
+                  <span>From</span>
+                  <input id="global-schedule-start" type="time" />
                 </label>
-                <label class="number-field">
-                  <span>Daily maximum</span>
-                  <input id="reddit-daily-usage-limit" name="redditDailyUsageLimitMinutes" type="number" min="5" max="240" step="5" />
-                  <small>minutes, fixed until tomorrow</small>
-                </label>
-              </div>
-            </fieldset>
-
-            <fieldset class="network-time-card">
-              <legend>X / Twitter</legend>
-              <div class="network-time-fields">
-                <label class="number-field">
-                  <span>Suggested session</span>
-                  <input id="x-session-duration" name="xSessionDurationMinutes" type="number" min="1" max="60" step="1" />
-                  <small>minutes</small>
-                </label>
-                <label class="number-field">
-                  <span>Daily maximum</span>
-                  <input id="x-daily-usage-limit" name="xDailyUsageLimitMinutes" type="number" min="5" max="240" step="5" />
-                  <small>minutes, fixed until tomorrow</small>
+                <label>
+                  <span>To</span>
+                  <input id="global-schedule-end" type="time" />
                 </label>
               </div>
-            </fieldset>
-
-            <fieldset class="network-time-card">
-              <legend>Instagram</legend>
-              <div class="network-time-fields">
-                <label class="number-field">
-                  <span>Suggested session</span>
-                  <input id="instagram-session-duration" name="instagramSessionDurationMinutes" type="number" min="1" max="60" step="1" />
-                  <small>minutes</small>
-                </label>
-                <label class="number-field">
-                  <span>Daily maximum</span>
-                  <input id="instagram-daily-usage-limit" name="instagramDailyUsageLimitMinutes" type="number" min="5" max="240" step="5" />
-                  <small>minutes, fixed until tomorrow</small>
-                </label>
-              </div>
-            </fieldset>
-
-            <fieldset class="network-time-card">
-              <legend>YouTube</legend>
-              <div class="network-time-fields">
-                <label class="number-field">
-                  <span>Suggested session</span>
-                  <input id="youtube-session-duration" name="youtubeSessionDurationMinutes" type="number" min="1" max="60" step="1" />
-                  <small>minutes</small>
-                </label>
-                <label class="number-field">
-                  <span>Daily maximum</span>
-                  <input id="youtube-daily-usage-limit" name="youtubeDailyUsageLimitMinutes" type="number" min="5" max="240" step="5" />
-                  <small>minutes, fixed until tomorrow</small>
-                </label>
-              </div>
-            </fieldset>
+              <fieldset class="day-picker">
+                <legend>Active days</legend>
+                <label><input type="checkbox" data-schedule-day="global" value="monday" /><span>Mon</span></label>
+                <label><input type="checkbox" data-schedule-day="global" value="tuesday" /><span>Tue</span></label>
+                <label><input type="checkbox" data-schedule-day="global" value="wednesday" /><span>Wed</span></label>
+                <label><input type="checkbox" data-schedule-day="global" value="thursday" /><span>Thu</span></label>
+                <label><input type="checkbox" data-schedule-day="global" value="friday" /><span>Fri</span></label>
+                <label><input type="checkbox" data-schedule-day="global" value="saturday" /><span>Sat</span></label>
+                <label><input type="checkbox" data-schedule-day="global" value="sunday" /><span>Sun</span></label>
+              </fieldset>
+              <p class="schedule-hint">If the end is earlier than the start, the window continues overnight. Matching times cover the full selected day.</p>
+            </div>
           </div>
         </section>
 
         <section class="panel">
           <div class="section-number">02</div>
+          <div class="section-heading">
+            <h2>Networks</h2>
+            <p>Each network keeps its activation, time budget and schedule together.</p>
+          </div>
+
+          <div class="network-grid">
+            <article class="network-card">
+              <header class="network-card__header">
+                <div><span class="network-kicker">Network 01</span><h3>Reddit</h3></div>
+                <label class="compact-toggle"><span>Enabled</span><input id="site-reddit" type="checkbox" /></label>
+              </header>
+              <div class="network-card__body">
+                <div class="network-time-fields">
+                <label class="number-field">
+                  <span>Suggested session</span>
+                  <input id="reddit-session-duration" type="number" min="1" max="60" step="1" />
+                  <small>minutes</small>
+                </label>
+                <label class="number-field">
+                  <span>Daily maximum</span>
+                  <input id="reddit-daily-usage-limit" type="number" min="5" max="240" step="5" />
+                  <small>minutes, fixed until tomorrow</small>
+                </label>
+              </div>
+                <label class="select-field"><span>Limits schedule</span><select id="reddit-schedule-mode"><option value="global">Use global schedule</option><option value="custom">Custom schedule</option><option value="always">Always active</option></select></label>
+                <div id="reddit-schedule-fields" class="schedule-fields schedule-fields--network">
+                  <div class="time-range"><label><span>From</span><input id="reddit-schedule-start" type="time" /></label><label><span>To</span><input id="reddit-schedule-end" type="time" /></label></div>
+                  <fieldset class="day-picker"><legend>Active days</legend>
+                    <label><input type="checkbox" data-schedule-day="reddit" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="reddit" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="reddit" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="reddit" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="reddit" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="reddit" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="reddit" value="sunday" /><span>Sun</span></label>
+                  </fieldset>
+                </div>
+              </div>
+            </article>
+
+            <article class="network-card">
+              <header class="network-card__header">
+                <div><span class="network-kicker">Network 02</span><h3>X / Twitter</h3></div>
+                <label class="compact-toggle"><span>Enabled</span><input id="site-x" type="checkbox" /></label>
+              </header>
+              <div class="network-card__body">
+              <div class="network-time-fields">
+                <label class="number-field">
+                  <span>Suggested session</span>
+                  <input id="x-session-duration" type="number" min="1" max="60" step="1" />
+                  <small>minutes</small>
+                </label>
+                <label class="number-field">
+                  <span>Daily maximum</span>
+                  <input id="x-daily-usage-limit" type="number" min="5" max="240" step="5" />
+                  <small>minutes, fixed until tomorrow</small>
+                </label>
+              </div>
+                <label class="select-field"><span>Limits schedule</span><select id="x-schedule-mode"><option value="global">Use global schedule</option><option value="custom">Custom schedule</option><option value="always">Always active</option></select></label>
+                <div id="x-schedule-fields" class="schedule-fields schedule-fields--network">
+                  <div class="time-range"><label><span>From</span><input id="x-schedule-start" type="time" /></label><label><span>To</span><input id="x-schedule-end" type="time" /></label></div>
+                  <fieldset class="day-picker"><legend>Active days</legend>
+                    <label><input type="checkbox" data-schedule-day="x" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="x" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="x" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="x" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="x" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="x" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="x" value="sunday" /><span>Sun</span></label>
+                  </fieldset>
+                </div>
+                <label class="card-option"><span><strong>Following only</strong><small>Prefer Following and hide For You.</small></span><input id="x-following-only" type="checkbox" /></label>
+              </div>
+            </article>
+
+            <article class="network-card">
+              <header class="network-card__header">
+                <div><span class="network-kicker">Network 03</span><h3>Instagram</h3></div>
+                <label class="compact-toggle"><span>Enabled</span><input id="site-instagram" type="checkbox" /></label>
+              </header>
+              <div class="network-card__body">
+              <div class="network-time-fields">
+                <label class="number-field">
+                  <span>Suggested session</span>
+                  <input id="instagram-session-duration" type="number" min="1" max="60" step="1" />
+                  <small>minutes</small>
+                </label>
+                <label class="number-field">
+                  <span>Daily maximum</span>
+                  <input id="instagram-daily-usage-limit" type="number" min="5" max="240" step="5" />
+                  <small>minutes, fixed until tomorrow</small>
+                </label>
+              </div>
+                <label class="select-field"><span>Limits schedule</span><select id="instagram-schedule-mode"><option value="global">Use global schedule</option><option value="custom">Custom schedule</option><option value="always">Always active</option></select></label>
+                <div id="instagram-schedule-fields" class="schedule-fields schedule-fields--network">
+                  <div class="time-range"><label><span>From</span><input id="instagram-schedule-start" type="time" /></label><label><span>To</span><input id="instagram-schedule-end" type="time" /></label></div>
+                  <fieldset class="day-picker"><legend>Active days</legend>
+                    <label><input type="checkbox" data-schedule-day="instagram" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="instagram" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="instagram" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="instagram" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="instagram" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="instagram" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="instagram" value="sunday" /><span>Sun</span></label>
+                  </fieldset>
+                </div>
+                <label class="card-option"><span><strong>Following only</strong><small>Open Following and hide For You.</small></span><input id="instagram-following-only" type="checkbox" /></label>
+              </div>
+            </article>
+
+            <article class="network-card">
+              <header class="network-card__header">
+                <div><span class="network-kicker">Network 04</span><h3>YouTube</h3></div>
+                <label class="compact-toggle"><span>Enabled</span><input id="site-youtube" type="checkbox" /></label>
+              </header>
+              <div class="network-card__body">
+              <div class="network-time-fields">
+                <label class="number-field">
+                  <span>Suggested session</span>
+                  <input id="youtube-session-duration" type="number" min="1" max="60" step="1" />
+                  <small>minutes</small>
+                </label>
+                <label class="number-field">
+                  <span>Daily maximum</span>
+                  <input id="youtube-daily-usage-limit" type="number" min="5" max="240" step="5" />
+                  <small>minutes, fixed until tomorrow</small>
+                </label>
+              </div>
+                <label class="select-field"><span>Limits schedule</span><select id="youtube-schedule-mode"><option value="global">Use global schedule</option><option value="custom">Custom schedule</option><option value="always">Always active</option></select></label>
+                <div id="youtube-schedule-fields" class="schedule-fields schedule-fields--network">
+                  <div class="time-range"><label><span>From</span><input id="youtube-schedule-start" type="time" /></label><label><span>To</span><input id="youtube-schedule-end" type="time" /></label></div>
+                  <fieldset class="day-picker"><legend>Active days</legend>
+                    <label><input type="checkbox" data-schedule-day="youtube" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="youtube" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="youtube" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="youtube" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="youtube" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="youtube" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="youtube" value="sunday" /><span>Sun</span></label>
+                  </fieldset>
+                </div>
+                <label class="card-option"><span><strong>Subscriptions only</strong><small>Redirect Home to Subscriptions.</small></span><input id="youtube-subscriptions-only" type="checkbox" /></label>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="section-number">04</div>
           <div class="section-heading">
             <h2>Entry pace</h2>
             <p>Add a pause before opening a feed.</p>
@@ -179,7 +271,7 @@
         </section>
 
         <section class="panel">
-          <div class="section-number">04</div>
+          <div class="section-number">05</div>
           <div class="section-heading">
             <h2>Friction</h2>
             <p>How much effort it takes to intentionally choose another batch.</p>
@@ -200,20 +292,13 @@
         </section>
 
         <section class="panel">
-          <div class="section-number">05</div>
+          <div class="section-number">06</div>
           <div class="section-heading">
-            <h2>Networks and noise</h2>
-            <p>Detection is an early version; selectors will evolve with testing.</p>
+            <h2>Noise</h2>
+            <p>Keep optional content and media behavior consistent across enabled networks.</p>
           </div>
 
           <div class="toggle-list">
-            <label><span>Reddit</span><input id="site-reddit" type="checkbox" /></label>
-            <label><span>X / Twitter</span><input id="site-x" type="checkbox" /></label>
-            <label><span>X: Following only</span><input id="x-following-only" type="checkbox" /></label>
-            <label><span>Instagram</span><input id="site-instagram" type="checkbox" /></label>
-            <label><span>Instagram: Following only</span><input id="instagram-following-only" type="checkbox" /></label>
-            <label><span>YouTube</span><input id="site-youtube" type="checkbox" /></label>
-            <label><span>YouTube: Subscriptions only</span><input id="youtube-subscriptions-only" type="checkbox" /></label>
             <label><span>Hide suggestions</span><input id="block-suggested" type="checkbox" /></label>
             <label><span>Stop autoplay</span><input id="disable-autoplay" type="checkbox" /></label>
           </div>

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -1,9 +1,11 @@
 import "./style.css";
 import {
-  DEFAULT_SETTINGS,
   sanitizeSettings,
+  type LimitScheduleMode,
   type PlatformId,
   type Settings,
+  type WeekdayId,
+  type WeeklyLimitSchedule,
 } from "../../lib/models";
 import {
   getSettings,
@@ -18,6 +20,12 @@ const controls = {
   openingDelay: requiredElement<HTMLInputElement>("#opening-delay"),
   openingDelayOutput: requiredElement<HTMLOutputElement>(
     "#opening-delay-output",
+  ),
+  globalScheduleEnabled: requiredElement<HTMLInputElement>(
+    "#global-schedule-enabled",
+  ),
+  globalScheduleFields: requiredElement<HTMLElement>(
+    "#global-schedule-fields",
   ),
   unlockDelay: requiredElement<HTMLInputElement>("#unlock-delay"),
   unlockDelayOutput:
@@ -42,25 +50,52 @@ const controls = {
   disableAutoplay: requiredElement<HTMLInputElement>("#disable-autoplay"),
 };
 
-const timeControls: Record<
+interface ScheduleControls {
+  start: HTMLInputElement;
+  end: HTMLInputElement;
+  fields: HTMLElement;
+  days: Record<WeekdayId, HTMLInputElement>;
+}
+
+interface NetworkControls {
+  sessionDuration: HTMLInputElement;
+  dailyUsageLimit: HTMLInputElement;
+  scheduleMode: HTMLSelectElement;
+  schedule: ScheduleControls;
+}
+
+const globalScheduleControls: ScheduleControls = createScheduleControls(
+  "global",
+  controls.globalScheduleFields,
+);
+
+const networkControls: Record<
   PlatformId,
-  { sessionDuration: HTMLInputElement; dailyUsageLimit: HTMLInputElement }
+  NetworkControls
 > = {
   reddit: {
     sessionDuration: requiredElement("#reddit-session-duration"),
     dailyUsageLimit: requiredElement("#reddit-daily-usage-limit"),
+    scheduleMode: requiredElement("#reddit-schedule-mode"),
+    schedule: createScheduleControls("reddit"),
   },
   x: {
     sessionDuration: requiredElement("#x-session-duration"),
     dailyUsageLimit: requiredElement("#x-daily-usage-limit"),
+    scheduleMode: requiredElement("#x-schedule-mode"),
+    schedule: createScheduleControls("x"),
   },
   instagram: {
     sessionDuration: requiredElement("#instagram-session-duration"),
     dailyUsageLimit: requiredElement("#instagram-daily-usage-limit"),
+    scheduleMode: requiredElement("#instagram-schedule-mode"),
+    schedule: createScheduleControls("instagram"),
   },
   youtube: {
     sessionDuration: requiredElement("#youtube-session-duration"),
     dailyUsageLimit: requiredElement("#youtube-daily-usage-limit"),
+    scheduleMode: requiredElement("#youtube-schedule-mode"),
+    schedule: createScheduleControls("youtube"),
   },
 };
 
@@ -68,6 +103,30 @@ function requiredElement<T extends Element>(selector: string): T {
   const element = document.querySelector<T>(selector);
   if (!element) throw new Error(`Missing options element: ${selector}`);
   return element;
+}
+
+function createScheduleControls(
+  scope: "global" | PlatformId,
+  fields = requiredElement<HTMLElement>(`#${scope}-schedule-fields`),
+): ScheduleControls {
+  const day = (weekday: WeekdayId) =>
+    requiredElement<HTMLInputElement>(
+      `[data-schedule-day="${scope}"][value="${weekday}"]`,
+    );
+  return {
+    start: requiredElement(`#${scope}-schedule-start`),
+    end: requiredElement(`#${scope}-schedule-end`),
+    fields,
+    days: {
+      monday: day("monday"),
+      tuesday: day("tuesday"),
+      wednesday: day("wednesday"),
+      thursday: day("thursday"),
+      friday: day("friday"),
+      saturday: day("saturday"),
+      sunday: day("sunday"),
+    },
+  };
 }
 
 function updateOutputs(): void {
@@ -79,12 +138,21 @@ function updateOutputs(): void {
 function render(settings: Settings): void {
   controls.enabled.checked = settings.enabled;
   controls.openingDelay.value = String(settings.openingDelaySeconds);
-  for (const platform of Object.keys(timeControls) as PlatformId[]) {
-    timeControls[platform].sessionDuration.value = String(
+  controls.globalScheduleEnabled.checked =
+    settings.limitSchedule.globalEnabled;
+  renderSchedule(globalScheduleControls, settings.limitSchedule.global);
+  for (const platform of Object.keys(networkControls) as PlatformId[]) {
+    networkControls[platform].sessionDuration.value = String(
       settings.sessionDurationMinutesByPlatform[platform],
     );
-    timeControls[platform].dailyUsageLimit.value = String(
+    networkControls[platform].dailyUsageLimit.value = String(
       settings.dailyUsageLimitMinutesByPlatform[platform],
+    );
+    networkControls[platform].scheduleMode.value =
+      settings.limitSchedule.modeByPlatform[platform];
+    renderSchedule(
+      networkControls[platform].schedule,
+      settings.limitSchedule.byPlatform[platform],
     );
   }
   controls.unlockDelay.value = String(settings.unlockDelaySeconds);
@@ -101,6 +169,43 @@ function render(settings: Settings): void {
   controls.blockSuggested.checked = settings.blockSuggested;
   controls.disableAutoplay.checked = settings.disableAutoplay;
   updateOutputs();
+  updateScheduleVisibility();
+}
+
+function renderSchedule(
+  scheduleControls: ScheduleControls,
+  schedule: WeeklyLimitSchedule,
+): void {
+  scheduleControls.start.value = schedule.startTime;
+  scheduleControls.end.value = schedule.endTime;
+  for (const weekday of Object.keys(scheduleControls.days) as WeekdayId[]) {
+    scheduleControls.days[weekday].checked = schedule.days[weekday];
+  }
+}
+
+function readSchedule(scheduleControls: ScheduleControls): WeeklyLimitSchedule {
+  return {
+    startTime: scheduleControls.start.value,
+    endTime: scheduleControls.end.value,
+    days: {
+      monday: scheduleControls.days.monday.checked,
+      tuesday: scheduleControls.days.tuesday.checked,
+      wednesday: scheduleControls.days.wednesday.checked,
+      thursday: scheduleControls.days.thursday.checked,
+      friday: scheduleControls.days.friday.checked,
+      saturday: scheduleControls.days.saturday.checked,
+      sunday: scheduleControls.days.sunday.checked,
+    },
+  };
+}
+
+function updateScheduleVisibility(): void {
+  controls.globalScheduleFields.hidden =
+    !controls.globalScheduleEnabled.checked;
+  for (const platform of Object.keys(networkControls) as PlatformId[]) {
+    networkControls[platform].schedule.fields.hidden =
+      networkControls[platform].scheduleMode.value !== "custom";
+  }
 }
 
 function readSettings(): Settings {
@@ -108,16 +213,16 @@ function readSettings(): Settings {
     enabled: controls.enabled.checked,
     openingDelaySeconds: Number(controls.openingDelay.value),
     sessionDurationMinutesByPlatform: {
-      reddit: Number(timeControls.reddit.sessionDuration.value),
-      x: Number(timeControls.x.sessionDuration.value),
-      instagram: Number(timeControls.instagram.sessionDuration.value),
-      youtube: Number(timeControls.youtube.sessionDuration.value),
+      reddit: Number(networkControls.reddit.sessionDuration.value),
+      x: Number(networkControls.x.sessionDuration.value),
+      instagram: Number(networkControls.instagram.sessionDuration.value),
+      youtube: Number(networkControls.youtube.sessionDuration.value),
     },
     dailyUsageLimitMinutesByPlatform: {
-      reddit: Number(timeControls.reddit.dailyUsageLimit.value),
-      x: Number(timeControls.x.dailyUsageLimit.value),
-      instagram: Number(timeControls.instagram.dailyUsageLimit.value),
-      youtube: Number(timeControls.youtube.dailyUsageLimit.value),
+      reddit: Number(networkControls.reddit.dailyUsageLimit.value),
+      x: Number(networkControls.x.dailyUsageLimit.value),
+      instagram: Number(networkControls.instagram.dailyUsageLimit.value),
+      youtube: Number(networkControls.youtube.dailyUsageLimit.value),
     },
     unlockDelaySeconds: Number(controls.unlockDelay.value),
     batchSize: Number(controls.batchSize.value),
@@ -134,12 +239,41 @@ function readSettings(): Settings {
       instagram: controls.instagram.checked,
       youtube: controls.youtube.checked,
     },
+    limitSchedule: {
+      globalEnabled: controls.globalScheduleEnabled.checked,
+      global: readSchedule(globalScheduleControls),
+      modeByPlatform: {
+        reddit: networkControls.reddit.scheduleMode.value as LimitScheduleMode,
+        x: networkControls.x.scheduleMode.value as LimitScheduleMode,
+        instagram: networkControls.instagram.scheduleMode
+          .value as LimitScheduleMode,
+        youtube: networkControls.youtube.scheduleMode
+          .value as LimitScheduleMode,
+      },
+      byPlatform: {
+        reddit: readSchedule(networkControls.reddit.schedule),
+        x: readSchedule(networkControls.x.schedule),
+        instagram: readSchedule(networkControls.instagram.schedule),
+        youtube: readSchedule(networkControls.youtube.schedule),
+      },
+    },
   });
 }
 
 [controls.openingDelay, controls.unlockDelay, controls.holdSeconds].forEach(
   (control) => control.addEventListener("input", updateOutputs),
 );
+
+controls.globalScheduleEnabled.addEventListener(
+  "change",
+  updateScheduleVisibility,
+);
+for (const platform of Object.keys(networkControls) as PlatformId[]) {
+  networkControls[platform].scheduleMode.addEventListener(
+    "change",
+    updateScheduleVisibility,
+  );
+}
 
 controls.xFollowingOnly.addEventListener("change", async () => {
   await saveSettings(readSettings());
@@ -169,7 +303,7 @@ form.addEventListener("submit", async (event) => {
   event.preventDefault();
   await saveSettings(readSettings());
   status.textContent =
-    "Saved. Changes to today's time ceiling apply tomorrow.";
+    "Saved. Schedules apply now; changes to today's time ceiling apply tomorrow.";
   window.setTimeout(() => {
     status.textContent = "";
   }, 2400);

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -24,7 +24,8 @@ body {
 }
 
 button,
-input {
+input,
+select {
   font: inherit;
 }
 
@@ -118,7 +119,8 @@ input {
 
 .field,
 .number-grid,
-.network-time-grid,
+.schedule-card,
+.network-grid,
 .toggle-list {
   grid-column: 2;
 }
@@ -147,22 +149,170 @@ input {
   gap: 10px;
 }
 
-.network-time-grid {
+.schedule-card {
   display: grid;
-  gap: 14px;
-}
-
-.network-time-card {
-  min-width: 0;
-  margin: 0;
-  padding: 16px;
+  gap: 18px;
+  padding: 18px;
   border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.3);
 }
 
-.network-time-card legend {
-  padding: 0 8px;
+.schedule-toggle,
+.compact-toggle,
+.card-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.schedule-toggle > span,
+.card-option > span {
+  display: grid;
+  gap: 2px;
+}
+
+.schedule-toggle small,
+.card-option small,
+.schedule-hint {
+  color: var(--muted);
+}
+
+.schedule-fields {
+  display: grid;
+  gap: 16px;
+}
+
+.schedule-fields[hidden] {
+  display: none;
+}
+
+.time-range {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.time-range label,
+.select-field {
+  display: grid;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.time-range input,
+.select-field select {
+  width: 100%;
+  min-height: 44px;
+  padding: 8px 10px;
+  border: 1px solid var(--line);
+  border-radius: 0;
+  color: var(--ink);
+  background: var(--paper);
+}
+
+.day-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.day-picker legend {
+  width: 100%;
+  margin-bottom: 2px;
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.day-picker label {
+  cursor: pointer;
+}
+
+.day-picker input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.day-picker span {
+  display: grid;
+  min-width: 42px;
+  min-height: 38px;
+  place-items: center;
+  padding: 6px 8px;
+  border: 1px solid var(--line);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.day-picker input:checked + span {
+  border-color: var(--ink);
+  color: var(--paper);
+  background: var(--ink);
+}
+
+.day-picker input:focus-visible + span {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
+}
+
+.schedule-hint {
+  margin: 0;
+  font-size: 12px;
+}
+
+.network-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.network-card {
+  min-width: 0;
+  border: 1px solid var(--ink);
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.network-card__header {
+  display: flex;
+  min-height: 88px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-bottom: 1px solid var(--ink);
+  background: var(--paper-strong);
+}
+
+.network-card__header h3 {
+  margin: 2px 0 0;
   font-family: "Iowan Old Style", "Palatino Linotype", serif;
-  font-size: 24px;
+  font-size: 28px;
+  font-weight: 500;
+  letter-spacing: -0.035em;
+}
+
+.network-kicker {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.network-card__body {
+  display: grid;
+  gap: 18px;
+  padding: 16px;
 }
 
 .network-time-fields {
@@ -170,10 +320,26 @@ input {
   gap: 10px;
 }
 
-.network-time-card .number-field {
-  padding: 12px 0;
-  border: 0;
+.network-card .number-field {
+  padding: 12px;
+}
+
+.schedule-fields--network {
+  padding: 14px;
+  border-left: 3px solid var(--acid);
+  background: rgba(24, 32, 24, 0.045);
+}
+
+.card-option {
+  min-height: 58px;
+  padding-top: 14px;
   border-top: 1px solid var(--line);
+}
+
+.compact-toggle {
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
 }
 
 .number-field {
@@ -223,7 +389,10 @@ input {
 }
 
 .toggle-list input,
-.master-toggle input {
+.master-toggle input,
+.schedule-toggle input,
+.compact-toggle input,
+.card-option input {
   width: 22px;
   height: 22px;
   accent-color: var(--ink);
@@ -311,7 +480,11 @@ input {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  .network-time-grid {
+  .network-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .network-time-fields {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 

--- a/lib/limit-schedule.ts
+++ b/lib/limit-schedule.ts
@@ -1,0 +1,67 @@
+import type {
+  PlatformId,
+  Settings,
+  WeekdayId,
+  WeeklyLimitSchedule,
+} from "./models";
+
+const WEEKDAY_BY_JS_DAY: WeekdayId[] = [
+  "sunday",
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+];
+
+export function areLimitsActive(
+  settings: Settings,
+  platform: PlatformId,
+  date = new Date(),
+): boolean {
+  const mode = settings.limitSchedule.modeByPlatform[platform];
+  if (mode === "always") return true;
+  if (mode === "global" && !settings.limitSchedule.globalEnabled) return true;
+
+  const schedule =
+    mode === "custom"
+      ? settings.limitSchedule.byPlatform[platform]
+      : settings.limitSchedule.global;
+  return isWithinWeeklySchedule(schedule, date);
+}
+
+export function isWithinWeeklySchedule(
+  schedule: WeeklyLimitSchedule,
+  date: Date,
+): boolean {
+  const currentMinutes = date.getHours() * 60 + date.getMinutes();
+  const startMinutes = parseClockMinutes(schedule.startTime);
+  const endMinutes = parseClockMinutes(schedule.endTime);
+  const today = weekdayFor(date);
+
+  if (startMinutes === endMinutes) return schedule.days[today];
+  if (startMinutes < endMinutes) {
+    return (
+      schedule.days[today] &&
+      currentMinutes >= startMinutes &&
+      currentMinutes < endMinutes
+    );
+  }
+
+  if (currentMinutes >= startMinutes) return schedule.days[today];
+  if (currentMinutes >= endMinutes) return false;
+
+  const previousDate = new Date(date);
+  previousDate.setDate(previousDate.getDate() - 1);
+  return schedule.days[weekdayFor(previousDate)];
+}
+
+function weekdayFor(date: Date): WeekdayId {
+  return WEEKDAY_BY_JS_DAY[date.getDay()] ?? "monday";
+}
+
+function parseClockMinutes(value: string): number {
+  const [hours = "0", minutes = "0"] = value.split(":");
+  return Number(hours) * 60 + Number(minutes);
+}

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -2,6 +2,33 @@ export type PlatformId = "reddit" | "x" | "instagram" | "youtube";
 
 export type PlatformMinutes = Record<PlatformId, number>;
 
+export const WEEKDAY_IDS = [
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+] as const;
+
+export type WeekdayId = (typeof WEEKDAY_IDS)[number];
+
+export type LimitScheduleMode = "global" | "custom" | "always";
+
+export interface WeeklyLimitSchedule {
+  startTime: string;
+  endTime: string;
+  days: Record<WeekdayId, boolean>;
+}
+
+export interface LimitScheduleSettings {
+  globalEnabled: boolean;
+  global: WeeklyLimitSchedule;
+  modeByPlatform: Record<PlatformId, LimitScheduleMode>;
+  byPlatform: Record<PlatformId, WeeklyLimitSchedule>;
+}
+
 export interface Settings {
   enabled: boolean;
   openingDelaySeconds: number;
@@ -17,6 +44,7 @@ export interface Settings {
   instagramFollowingOnly: boolean;
   youtubeSubscriptionsOnly: boolean;
   enabledSites: Record<PlatformId, boolean>;
+  limitSchedule: LimitScheduleSettings;
 }
 
 export interface DailyState {
@@ -63,16 +91,48 @@ export const DEFAULT_SETTINGS: Settings = {
     instagram: true,
     youtube: true,
   },
+  limitSchedule: {
+    globalEnabled: false,
+    global: createDefaultWeeklySchedule(),
+    modeByPlatform: {
+      reddit: "global",
+      x: "global",
+      instagram: "global",
+      youtube: "global",
+    },
+    byPlatform: {
+      reddit: createDefaultWeeklySchedule(),
+      x: createDefaultWeeklySchedule(),
+      instagram: createDefaultWeeklySchedule(),
+      youtube: createDefaultWeeklySchedule(),
+    },
+  },
+};
+
+type WeeklyLimitScheduleInput = {
+  startTime?: unknown;
+  endTime?: unknown;
+  days?: Partial<Record<WeekdayId, unknown>>;
+};
+
+type LimitScheduleSettingsInput = {
+  globalEnabled?: unknown;
+  global?: WeeklyLimitScheduleInput;
+  modeByPlatform?: Partial<Record<PlatformId, unknown>>;
+  byPlatform?: Partial<Record<PlatformId, WeeklyLimitScheduleInput>>;
 };
 
 type SettingsInput = Partial<
   Omit<
     Settings,
-    "sessionDurationMinutesByPlatform" | "dailyUsageLimitMinutesByPlatform"
+    | "sessionDurationMinutesByPlatform"
+    | "dailyUsageLimitMinutesByPlatform"
+    | "limitSchedule"
   >
 > & {
   sessionDurationMinutesByPlatform?: Partial<PlatformMinutes>;
   dailyUsageLimitMinutesByPlatform?: Partial<PlatformMinutes>;
+  limitSchedule?: LimitScheduleSettingsInput;
   sessionDurationMinutes?: number;
   dailyUsageLimitMinutes?: number;
 };
@@ -183,6 +243,7 @@ export function sanitizeSettings(input: SettingsInput): Settings {
         DEFAULT_SETTINGS.enabledSites.youtube,
       ),
     },
+    limitSchedule: sanitizeLimitSchedule(input.limitSchedule),
   };
 }
 
@@ -331,6 +392,113 @@ function sanitizePlatformMinutes(
     instagram: clampInteger(values?.instagram, fallback, minimum, maximum),
     youtube: clampInteger(values?.youtube, fallback, minimum, maximum),
   };
+}
+
+function createDefaultWeeklySchedule(): WeeklyLimitSchedule {
+  return {
+    startTime: "09:00",
+    endTime: "22:00",
+    days: {
+      monday: true,
+      tuesday: true,
+      wednesday: true,
+      thursday: true,
+      friday: true,
+      saturday: true,
+      sunday: true,
+    },
+  };
+}
+
+function sanitizeLimitSchedule(
+  input: LimitScheduleSettingsInput | undefined,
+): LimitScheduleSettings {
+  const fallback = DEFAULT_SETTINGS.limitSchedule;
+  return {
+    globalEnabled: sanitizeBoolean(
+      input?.globalEnabled,
+      fallback.globalEnabled,
+    ),
+    global: sanitizeWeeklySchedule(input?.global, fallback.global),
+    modeByPlatform: {
+      reddit: sanitizeScheduleMode(
+        input?.modeByPlatform?.reddit,
+        fallback.modeByPlatform.reddit,
+      ),
+      x: sanitizeScheduleMode(
+        input?.modeByPlatform?.x,
+        fallback.modeByPlatform.x,
+      ),
+      instagram: sanitizeScheduleMode(
+        input?.modeByPlatform?.instagram,
+        fallback.modeByPlatform.instagram,
+      ),
+      youtube: sanitizeScheduleMode(
+        input?.modeByPlatform?.youtube,
+        fallback.modeByPlatform.youtube,
+      ),
+    },
+    byPlatform: {
+      reddit: sanitizeWeeklySchedule(
+        input?.byPlatform?.reddit,
+        fallback.byPlatform.reddit,
+      ),
+      x: sanitizeWeeklySchedule(
+        input?.byPlatform?.x,
+        fallback.byPlatform.x,
+      ),
+      instagram: sanitizeWeeklySchedule(
+        input?.byPlatform?.instagram,
+        fallback.byPlatform.instagram,
+      ),
+      youtube: sanitizeWeeklySchedule(
+        input?.byPlatform?.youtube,
+        fallback.byPlatform.youtube,
+      ),
+    },
+  };
+}
+
+function sanitizeWeeklySchedule(
+  input: WeeklyLimitScheduleInput | undefined,
+  fallback: WeeklyLimitSchedule,
+): WeeklyLimitSchedule {
+  return {
+    startTime: sanitizeClockTime(input?.startTime, fallback.startTime),
+    endTime: sanitizeClockTime(input?.endTime, fallback.endTime),
+    days: {
+      monday: sanitizeBoolean(input?.days?.monday, fallback.days.monday),
+      tuesday: sanitizeBoolean(input?.days?.tuesday, fallback.days.tuesday),
+      wednesday: sanitizeBoolean(
+        input?.days?.wednesday,
+        fallback.days.wednesday,
+      ),
+      thursday: sanitizeBoolean(
+        input?.days?.thursday,
+        fallback.days.thursday,
+      ),
+      friday: sanitizeBoolean(input?.days?.friday, fallback.days.friday),
+      saturday: sanitizeBoolean(
+        input?.days?.saturday,
+        fallback.days.saturday,
+      ),
+      sunday: sanitizeBoolean(input?.days?.sunday, fallback.days.sunday),
+    },
+  };
+}
+
+function sanitizeScheduleMode(
+  value: unknown,
+  fallback: LimitScheduleMode,
+): LimitScheduleMode {
+  return value === "global" || value === "custom" || value === "always"
+    ? value
+    : fallback;
+}
+
+function sanitizeClockTime(value: unknown, fallback: string): string {
+  if (typeof value !== "string") return fallback;
+  return /^(?:[01]\d|2[0-3]):[0-5]\d$/.test(value) ? value : fallback;
 }
 
 function normalizeDailyLimit(value: number | undefined): number | undefined {

--- a/tests/limit-schedule.test.ts
+++ b/tests/limit-schedule.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  areLimitsActive,
+  isWithinWeeklySchedule,
+} from "../lib/limit-schedule";
+import {
+  DEFAULT_SETTINGS,
+  type WeeklyLimitSchedule,
+} from "../lib/models";
+
+const mondayOnly = (
+  startTime: string,
+  endTime: string,
+): WeeklyLimitSchedule => ({
+  startTime,
+  endTime,
+  days: {
+    monday: true,
+    tuesday: false,
+    wednesday: false,
+    thursday: false,
+    friday: false,
+    saturday: false,
+    sunday: false,
+  },
+});
+
+describe("weekly limit schedules", () => {
+  it("uses an inclusive start and exclusive end on selected days", () => {
+    const schedule = mondayOnly("09:00", "17:00");
+
+    expect(
+      isWithinWeeklySchedule(schedule, new Date(2026, 7, 10, 9, 0)),
+    ).toBe(true);
+    expect(
+      isWithinWeeklySchedule(schedule, new Date(2026, 7, 10, 16, 59)),
+    ).toBe(true);
+    expect(
+      isWithinWeeklySchedule(schedule, new Date(2026, 7, 10, 17, 0)),
+    ).toBe(false);
+    expect(
+      isWithinWeeklySchedule(schedule, new Date(2026, 7, 11, 10, 0)),
+    ).toBe(false);
+  });
+
+  it("carries an overnight window into the following day", () => {
+    const schedule = mondayOnly("22:00", "07:00");
+
+    expect(
+      isWithinWeeklySchedule(schedule, new Date(2026, 7, 10, 23, 0)),
+    ).toBe(true);
+    expect(
+      isWithinWeeklySchedule(schedule, new Date(2026, 7, 11, 6, 59)),
+    ).toBe(true);
+    expect(
+      isWithinWeeklySchedule(schedule, new Date(2026, 7, 11, 7, 0)),
+    ).toBe(false);
+    expect(
+      isWithinWeeklySchedule(schedule, new Date(2026, 7, 11, 23, 0)),
+    ).toBe(false);
+  });
+
+  it("treats equal start and end times as the full selected day", () => {
+    const schedule = mondayOnly("00:00", "00:00");
+
+    expect(
+      isWithinWeeklySchedule(schedule, new Date(2026, 7, 10, 15, 30)),
+    ).toBe(true);
+    expect(
+      isWithinWeeklySchedule(schedule, new Date(2026, 7, 11, 15, 30)),
+    ).toBe(false);
+  });
+
+  it("supports global, custom and always-active modes per network", () => {
+    const mondayMorning = mondayOnly("09:00", "12:00");
+    const mondayEvening = mondayOnly("18:00", "21:00");
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      limitSchedule: {
+        ...DEFAULT_SETTINGS.limitSchedule,
+        globalEnabled: true,
+        global: mondayMorning,
+        modeByPlatform: {
+          reddit: "global" as const,
+          x: "custom" as const,
+          instagram: "always" as const,
+          youtube: "global" as const,
+        },
+        byPlatform: {
+          ...DEFAULT_SETTINGS.limitSchedule.byPlatform,
+          x: mondayEvening,
+        },
+      },
+    };
+
+    const mondayAtTen = new Date(2026, 7, 10, 10, 0);
+    const mondayAtNineteen = new Date(2026, 7, 10, 19, 0);
+    expect(areLimitsActive(settings, "reddit", mondayAtTen)).toBe(true);
+    expect(areLimitsActive(settings, "reddit", mondayAtNineteen)).toBe(false);
+    expect(areLimitsActive(settings, "x", mondayAtTen)).toBe(false);
+    expect(areLimitsActive(settings, "x", mondayAtNineteen)).toBe(true);
+    expect(areLimitsActive(settings, "instagram", mondayAtTen)).toBe(true);
+  });
+
+  it("keeps inherited limits active all day when global scheduling is off", () => {
+    expect(
+      areLimitsActive(
+        DEFAULT_SETTINGS,
+        "youtube",
+        new Date(2026, 7, 11, 3, 0),
+      ),
+    ).toBe(true);
+  });
+});

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -93,6 +93,44 @@ describe("settings", () => {
     expect(settings).not.toHaveProperty("dailyUsageLimitMinutes");
   });
 
+  it("sanitizes weekly schedules with backward-compatible defaults", () => {
+    const settings = sanitizeSettings({
+      limitSchedule: {
+        globalEnabled: true,
+        global: {
+          startTime: "25:00",
+          endTime: "08:30",
+          days: { monday: false },
+        },
+        modeByPlatform: {
+          reddit: "invalid",
+          instagram: "custom",
+        },
+        byPlatform: {
+          instagram: {
+            startTime: "20:15",
+            endTime: "06:45",
+            days: { saturday: false },
+          },
+        },
+      },
+    });
+
+    expect(settings.limitSchedule.globalEnabled).toBe(true);
+    expect(settings.limitSchedule.global.startTime).toBe("09:00");
+    expect(settings.limitSchedule.global.endTime).toBe("08:30");
+    expect(settings.limitSchedule.global.days.monday).toBe(false);
+    expect(settings.limitSchedule.global.days.tuesday).toBe(true);
+    expect(settings.limitSchedule.modeByPlatform.reddit).toBe("global");
+    expect(settings.limitSchedule.modeByPlatform.instagram).toBe("custom");
+    expect(settings.limitSchedule.byPlatform.instagram.startTime).toBe(
+      "20:15",
+    );
+    expect(settings.limitSchedule.byPlatform.instagram.days.saturday).toBe(
+      false,
+    );
+  });
+
   it("drops legacy post-limit and friction-mode settings", () => {
     const settings = sanitizeSettings({
       mode: "strict",


### PR DESCRIPTION
## What changed?

- Adds an optional weekly schedule for when feed and time limits are active.
- Lets each network inherit the global schedule, use its own weekdays/hours, or keep limits always active.
- Supports daytime, overnight and full-day windows using the browser's local clock.
- Re-evaluates schedule boundaries while a feed is open, flushing the active session when a window ends and activating limits when one begins.
- Reorganizes the options page into clear Reddit, X, Instagram and YouTube cards containing each network's enable switch, time budget, schedule and feed preference.
- Preserves previous installs: scheduling defaults to off globally, so existing limits remain active all day.

## Why?

Different networks may need limits at different times and on different days. Keeping each network's controls in one card also makes the relationship between activation, time budgets and scheduling easier to understand.

## User impact

Outside a network's active window, opening/session interventions, time accounting and finite feed batches are bypassed. Suggestion suppression and Following/Subscriptions preferences remain active. No permissions or remote data behavior change.

## How was it tested?

- `npm run validate` (typecheck, 60 tests, Firefox build and Chromium build)
- `npm run zip` (Firefox and Chromium production packages)
- Added tests for selected weekdays, exact boundaries, overnight windows, full-day windows, all three per-network modes and backward-compatible sanitization.

- [x] `npm run validate`
- [ ] Firefox
- [ ] Chromium
- [ ] Firefox for Android

## Contribution checklist

- [x] The PR has one clear purpose and its title follows Conventional Commits.
- [x] The PR targets `main`; it is independent because PR #47 is already merged.
- [x] I added or updated tests for behavior that can be tested automatically.
- [x] I documented user-facing settings and scheduling behavior.
- [x] I did not add analytics, remote data collection or new permissions.
- [x] I checked that no social-network selectors or route boundaries changed.
- [ ] I included screenshots or a short recording for visible interface changes.

## Notes for reviewers

The schedule uses inclusive starts and exclusive ends. Overnight windows belong to the selected start day; matching start/end times cover the full selected day. Manual browser/device smoke testing and an updated options screenshot remain for review.