### PR TITLE
fix(session): preserve countdown across reloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,10 @@ Post counters and time budgets are independent per network:
 - `Settings.limitSchedule` stores the optional global weekly window plus each
   platform's global, custom or always-active mode. Schedule changes apply on
   reactivation, and clock boundaries are detected by the content lifecycle.
+- Active planned countdowns are checkpointed in extension session storage by
+  tab and platform so full same-tab navigations do not reopen the initial time
+  picker. They are cleared when the countdown ends, protection is disabled or
+  the tab closes.
 
 Post batches can be unlocked repeatedly. Each unlock still requires the
 configured inline delay and press-and-hold interaction.
@@ -220,6 +224,8 @@ Preserve these invariants:
   the selected start day and continue into the following morning.
 - Usage is counted only while the supported feed document is visible.
 - Pending seconds are persisted on visibility loss, page hide and teardown.
+- A document reload may restore the active planned countdown, but must still
+  reconcile the daily remaining time from serialized storage before resuming.
 - A time-limit change cannot increase the effective ceiling for the current
   day.
 - Repeated activation must cancel stale asynchronous UI results.

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -39,8 +39,9 @@ Keep the useful parts of social networks while giving every feed a real end.
   minutes per network and can be adjusted from 1 to 60 minutes at entry.
 - A compact floating counter shows the planned session time and the remaining
   daily time for the current network. Once a session starts, the counter and
-  the chosen block survive same-network SPA navigation and browser history
-  changes instead of showing the opening screen again.
+  the chosen block survive same-network SPA navigation, browser history changes
+  and full document reloads in the same tab instead of showing the opening
+  screen again.
 - Time advances only while the tab is visible.
 - When planned time ends, the user can leave or deliberately plan another
   block after a 10-second pause. The next duration cannot be selected until
@@ -55,8 +56,9 @@ Keep the useful parts of social networks while giving every feed a real end.
   background context, and active tabs reconcile against persisted time usage
   from other tabs.
 - Aggregate elapsed seconds are retained locally for the 30 most recent days
-  with activity so usage statistics survive calendar resets. Active session
-  countdowns are not stored as history.
+  with activity so usage statistics survive calendar resets. The active
+  countdown is checkpointed separately per tab and network in extension session
+  storage, cleared when it ends or the tab closes, and never stored as history.
 - The effective ceiling is fixed for the day. Configuration changes apply on
   the next local calendar day, and the settings page cannot reset elapsed time.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ X/Twitter, Instagram, and YouTube. Post counts do not impose a maximum: every
 completed batch gate can reveal another configured batch.
 Preferences and aggregate counters stay in browser extension local storage.
 Elapsed seconds per network are retained for the 30 most recent days with
-activity; active session countdowns are not stored in that history.
+activity. The remaining active countdown is kept separately in extension
+session storage for the current tab and is not stored in usage history.
 At a closed batch boundary, blocked posts retain their layout geometry while
 becoming invisible and non-interactive. The inline control also occupies the
 remaining viewport, keeping native infinite-scroll loaders out of view.
@@ -63,8 +64,8 @@ hold before the next finite batch is revealed.
 - Immediate interaction guard while local settings and the opening
   intervention load, preventing clicks or scrolling through the feed first.
 - Per-network intentional session duration, adjusted through deliberate button
-  steps, with a floating countdown that remains active across same-network SPA
-  and history navigation.
+  steps, with a floating countdown that remains active across same-network SPA,
+  history navigation and full document reloads in the same tab.
 - Optional Following-only modes for X and Instagram that select followed
   content while keeping direct profiles available.
 - Intentional search on X, Instagram and Reddit: autocomplete or default

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -1,13 +1,23 @@
+import { storage } from "#imports";
 import {
   addUsageSecondsFromStorage,
   reserveAllowanceFromStorage,
 } from "../lib/storage";
-import { isRuntimeMessage } from "../lib/runtime-messages";
+import {
+  isRuntimeMessage,
+  type ActiveSessionSnapshot,
+} from "../lib/runtime-messages";
 import { SerialQueue } from "../lib/serial-queue";
 
 export type RuntimeMessageSender = Parameters<
   Parameters<typeof browser.runtime.onMessage.addListener>[0]
 >[1];
+
+const activeSessionKey = (
+  tabId: number,
+  platform: ActiveSessionSnapshot["platform"],
+): `session:${string}` =>
+  `session:dopamine-fast-active-session-${tabId}-${platform}`;
 
 export function createRuntimeMessageHandler() {
   const mutations = new SerialQueue();
@@ -31,6 +41,34 @@ export function createRuntimeMessageHandler() {
             message.elapsedSeconds,
           ),
         }));
+      case "dopamine-fast:set-active-session": {
+        const tabId = sender.tab?.id;
+        if (tabId === undefined) return { ok: false };
+        return mutations.run(async () => {
+          await storage.setItem(
+            activeSessionKey(tabId, message.session.platform),
+            message.session,
+          );
+          return { ok: true };
+        });
+      }
+      case "dopamine-fast:get-active-session": {
+        const tabId = sender.tab?.id;
+        if (tabId === undefined) return { session: null };
+        return mutations.run(async () => ({
+          session: await storage.getItem<ActiveSessionSnapshot>(
+            activeSessionKey(tabId, message.platform),
+          ),
+        }));
+      }
+      case "dopamine-fast:clear-active-session": {
+        const tabId = sender.tab?.id;
+        if (tabId === undefined) return { ok: false };
+        return mutations.run(async () => {
+          await storage.removeItem(activeSessionKey(tabId, message.platform));
+          return { ok: true };
+        });
+      }
       case "dopamine-fast:open-options":
         return browser.runtime.openOptionsPage().then(() => ({ ok: true }));
       case "dopamine-fast:leave-feed":
@@ -44,4 +82,11 @@ export function createRuntimeMessageHandler() {
 
 export default defineBackground(() => {
   browser.runtime.onMessage.addListener(createRuntimeMessageHandler());
+  browser.tabs.onRemoved.addListener((tabId) => {
+    void Promise.all(
+      (["reddit", "x", "instagram", "youtube"] as const).map((platform) =>
+        storage.removeItem(activeSessionKey(tabId, platform)),
+      ),
+    );
+  });
 });

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -14,10 +14,13 @@ import { PreferredFeedController } from "../lib/preferred-feed";
 import { SingleItemViewController } from "../lib/single-item-view";
 import { SurfaceSuppressionController } from "../lib/surface-suppression";
 import {
+  clearActiveSession,
+  getActiveSession,
   getDailyUsageState,
   getSettings,
   getUsageHistory,
   reserveAllowance,
+  saveActiveSession,
   dailyUsageStateItem,
   settingsItem,
 } from "../lib/storage";
@@ -95,6 +98,7 @@ export default defineContentScript({
     let singleItemView: SingleItemViewController | undefined;
     let surfaceSuppression: SurfaceSuppressionController | undefined;
     let usageSession: UsageSession | undefined;
+    let usageSessionNeedsAllowance = false;
     let sessionPostAllowance = 0;
     let currentUrl = "";
     let activationId = 0;
@@ -130,8 +134,12 @@ export default defineContentScript({
       if (!preserveUsageSession || !usageSession) {
         const previousUsageSession = usageSession;
         usageSession = undefined;
+        usageSessionNeedsAllowance = false;
         sessionPostAllowance = 0;
         await previousUsageSession?.destroy();
+        if (previousUsageSession) {
+          await clearActiveSession(adapter.id);
+        }
         if (thisActivation !== activationId) return;
         intervention.hideAll();
       }
@@ -140,8 +148,64 @@ export default defineContentScript({
       if (thisActivation !== activationId) return;
       currentSettings = settings;
       if (!settings.enabled || !settings.enabledSites[adapter.id]) {
+        const previousUsageSession = usageSession;
+        usageSession = undefined;
+        usageSessionNeedsAllowance = false;
+        sessionPostAllowance = 0;
+        await previousUsageSession?.destroy();
+        await clearActiveSession(adapter.id);
+        intervention.hideAll();
         return;
       }
+
+      const startUsageSession = (
+        plannedSeconds: number,
+        availableSeconds: number,
+      ) => {
+        const session = new UsageSession({
+          platform: adapter.id,
+          platformLabel: adapter.label,
+          plannedSeconds,
+          availableSeconds,
+          ui: intervention,
+          onCheckpoint(remainingPlannedSeconds) {
+            void saveActiveSession({
+              platform: adapter.id,
+              date: localDateKey(),
+              plannedSeconds: remainingPlannedSeconds,
+            });
+          },
+          onFinished() {
+            void clearActiveSession(adapter.id);
+          },
+          onPlannedTimeElapsed(remainingSeconds) {
+            void (async () => {
+              const extensionSeconds = await intervention.showSessionEnded({
+                platformLabel: adapter.label,
+                defaultSessionMinutes:
+                  settings.sessionDurationMinutesByPlatform[adapter.id],
+                availableSeconds: remainingSeconds,
+              });
+              if (usageSession !== session) {
+                return;
+              }
+              if (extensionSeconds <= 0) return;
+              session.extend(extensionSeconds);
+            })();
+          },
+          onHardLimitReached() {
+            if (usageSession !== session) {
+              return;
+            }
+            sessionPostAllowance = 0;
+            limiter?.destroy();
+            limiter = undefined;
+            intervention.showHardLimitReached(adapter.label);
+          },
+        });
+        usageSession = session;
+        session.start();
+      };
 
       const surfaceConfig = adapter.surfaceSuppression;
       const subscriptionsOnly =
@@ -188,6 +252,31 @@ export default defineContentScript({
         );
         singleItemView.start();
       }
+
+      if (!usageSession) {
+        const storedSession = await getActiveSession(adapter.id);
+        if (thisActivation !== activationId) return;
+        if (storedSession?.date !== localDateKey()) {
+          if (storedSession) await clearActiveSession(adapter.id);
+        } else {
+          const usageState = await getDailyUsageState();
+          if (thisActivation !== activationId) return;
+          const availableSeconds = availableUsageSeconds(
+            settings,
+            usageState,
+            adapter.id,
+          );
+          if (availableSeconds <= 0) {
+            await clearActiveSession(adapter.id);
+          } else {
+            usageSessionNeedsAllowance = true;
+            startUsageSession(
+              storedSession.plannedSeconds,
+              availableSeconds,
+            );
+          }
+        }
+      }
       if (isSingleItemRoute) {
         return;
       }
@@ -211,8 +300,10 @@ export default defineContentScript({
       if (!limitsAreActive) {
         const previousUsageSession = usageSession;
         usageSession = undefined;
+        usageSessionNeedsAllowance = false;
         sessionPostAllowance = 0;
         await previousUsageSession?.destroy();
+        await clearActiveSession(adapter.id);
         if (thisActivation !== activationId) return;
         intervention.hideAll();
         return;
@@ -222,6 +313,14 @@ export default defineContentScript({
         if (usageSession.getAvailableSeconds() <= 0) {
           intervention.showHardLimitReached(adapter.label);
           return;
+        }
+        if (usageSessionNeedsAllowance) {
+          sessionPostAllowance = await reserveAllowance(
+            adapter.id,
+            settings.batchSize,
+          );
+          if (thisActivation !== activationId) return;
+          usageSessionNeedsAllowance = false;
         }
         limiter = new FeedLimiter(adapter, settings, sessionPostAllowance);
         limiter.start();
@@ -276,39 +375,7 @@ export default defineContentScript({
       );
       limiter.start();
 
-      const session = new UsageSession({
-        platform: adapter.id,
-        platformLabel: adapter.label,
-        plannedSeconds,
-        availableSeconds,
-        ui: intervention,
-        onPlannedTimeElapsed(remainingSeconds) {
-          void (async () => {
-            const extensionSeconds = await intervention.showSessionEnded({
-              platformLabel: adapter.label,
-              defaultSessionMinutes:
-                settings.sessionDurationMinutesByPlatform[adapter.id],
-              availableSeconds: remainingSeconds,
-            });
-            if (usageSession !== session) {
-              return;
-            }
-            if (extensionSeconds <= 0) return;
-            session.extend(extensionSeconds);
-          })();
-        },
-        onHardLimitReached() {
-          if (usageSession !== session) {
-            return;
-          }
-          sessionPostAllowance = 0;
-          limiter?.destroy();
-          limiter = undefined;
-          intervention.showHardLimitReached(adapter.label);
-        },
-      });
-      usageSession = session;
-      session.start();
+      startUsageSession(plannedSeconds, availableSeconds);
       })().finally(() => interactionGuard.release(thisActivation));
     };
 
@@ -330,7 +397,7 @@ export default defineContentScript({
     }, 600);
 
     const unwatchSettings = settingsItem.watch(() => {
-      void activate();
+      void activate(true);
     });
 
     const unwatchUsage = dailyUsageStateItem.watch(() => {

--- a/lib/runtime-messages.ts
+++ b/lib/runtime-messages.ts
@@ -1,5 +1,11 @@
 import type { PlatformId } from "./models";
 
+export interface ActiveSessionSnapshot {
+  platform: PlatformId;
+  date: string;
+  plannedSeconds: number;
+}
+
 export type RuntimeMessage =
   | {
       type: "dopamine-fast:reserve-allowance";
@@ -12,6 +18,18 @@ export type RuntimeMessage =
       platform: PlatformId;
       elapsedSeconds: number;
     }
+  | {
+      type: "dopamine-fast:set-active-session";
+      session: ActiveSessionSnapshot;
+    }
+  | {
+      type: "dopamine-fast:get-active-session";
+      platform: PlatformId;
+    }
+  | {
+      type: "dopamine-fast:clear-active-session";
+      platform: PlatformId;
+    }
   | { type: "dopamine-fast:open-options" }
   | { type: "dopamine-fast:leave-feed" };
 
@@ -21,6 +39,10 @@ export interface ReserveAllowanceResponse {
 
 export interface AddUsageSecondsResponse {
   remainingSeconds: number;
+}
+
+export interface GetActiveSessionResponse {
+  session: ActiveSessionSnapshot | null;
 }
 
 export function isRuntimeMessage(value: unknown): value is RuntimeMessage {
@@ -38,6 +60,11 @@ export function isRuntimeMessage(value: unknown): value is RuntimeMessage {
         isPlatform(candidate.platform) &&
         isFiniteNumber(candidate.elapsedSeconds)
       );
+    case "dopamine-fast:set-active-session":
+      return isActiveSessionSnapshot(candidate.session);
+    case "dopamine-fast:get-active-session":
+    case "dopamine-fast:clear-active-session":
+      return isPlatform(candidate.platform);
     case "dopamine-fast:open-options":
     case "dopamine-fast:leave-feed":
       return true;
@@ -54,3 +81,18 @@ const isPlatform = (value: unknown): value is PlatformId =>
 
 const isFiniteNumber = (value: unknown): value is number =>
   typeof value === "number" && Number.isFinite(value);
+
+function isActiveSessionSnapshot(
+  value: unknown,
+): value is ActiveSessionSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    isPlatform(candidate.platform) &&
+    typeof candidate.date === "string" &&
+    /^\d{4}-\d{2}-\d{2}$/.test(candidate.date) &&
+    isFiniteNumber(candidate.plannedSeconds) &&
+    candidate.plannedSeconds > 0 &&
+    candidate.plannedSeconds <= 60 * 60
+  );
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -12,7 +12,9 @@ import {
   type Settings,
 } from "./models";
 import type {
+  ActiveSessionSnapshot,
   AddUsageSecondsResponse,
+  GetActiveSessionResponse,
   ReserveAllowanceResponse,
   RuntimeMessage,
 } from "./runtime-messages";
@@ -133,6 +135,40 @@ export async function addUsageSeconds(
     elapsedSeconds,
   });
   return response.remainingSeconds;
+}
+
+export async function saveActiveSession(
+  session: ActiveSessionSnapshot,
+): Promise<void> {
+  await browser.runtime.sendMessage<RuntimeMessage, { ok: boolean }>({
+    type: "dopamine-fast:set-active-session",
+    session: {
+      ...session,
+      plannedSeconds: Math.max(1, Math.round(session.plannedSeconds)),
+    },
+  });
+}
+
+export async function getActiveSession(
+  platform: PlatformId,
+): Promise<ActiveSessionSnapshot | null> {
+  const response = await browser.runtime.sendMessage<
+    RuntimeMessage,
+    GetActiveSessionResponse
+  >({
+    type: "dopamine-fast:get-active-session",
+    platform,
+  });
+  return response.session;
+}
+
+export async function clearActiveSession(
+  platform: PlatformId,
+): Promise<void> {
+  await browser.runtime.sendMessage<RuntimeMessage, { ok: boolean }>({
+    type: "dopamine-fast:clear-active-session",
+    platform,
+  });
 }
 
 export async function getUsageHistory(): Promise<UsageHistory> {

--- a/lib/usage-session.ts
+++ b/lib/usage-session.ts
@@ -8,6 +8,8 @@ export interface UsageSessionOptions {
   plannedSeconds: number;
   availableSeconds: number;
   ui: InterventionUi;
+  onCheckpoint?(plannedSeconds: number): void;
+  onFinished?(): void;
   onPlannedTimeElapsed(availableSeconds: number): void;
   onHardLimitReached(): void;
 }
@@ -72,6 +74,7 @@ export class UsageSession {
 
     this.state = "running";
     this.render();
+    this.checkpoint();
     this.environment.addVisibilityListener(this.persistWhenHidden);
     this.environment.addPageHideListener(this.persistBeforeLeaving);
     this.interval = this.environment.setInterval(() => this.tick(), 1000);
@@ -85,12 +88,14 @@ export class UsageSession {
     );
     this.state = "running";
     this.render();
+    this.checkpoint();
     this.interval = this.environment.setInterval(() => this.tick(), 1000);
   }
 
   async destroy(): Promise<void> {
     if (this.state === "destroyed") return;
     this.stopInterval();
+    this.checkpoint();
     this.state = "destroyed";
     this.environment.removeVisibilityListener(this.persistWhenHidden);
     this.environment.removePageHideListener(this.persistBeforeLeaving);
@@ -110,7 +115,11 @@ export class UsageSession {
     );
     this.plannedSeconds = Math.min(this.plannedSeconds, this.availableSeconds);
     this.render();
-    if (this.availableSeconds <= 0) this.finishHardLimit();
+    if (this.availableSeconds <= 0) {
+      this.finishHardLimit();
+      return;
+    }
+    this.checkpoint();
   }
 
   private tick(): void {
@@ -136,6 +145,8 @@ export class UsageSession {
       return;
     }
 
+    this.checkpoint();
+
     if (this.pendingSeconds >= 5) {
       void this.persistPending();
     }
@@ -153,6 +164,7 @@ export class UsageSession {
     if (this.state !== "running") return;
     this.stopInterval();
     this.state = "planned-end";
+    this.options.onFinished?.();
     void this.persistPending().then(() => {
       if (this.state !== "planned-end") return;
       if (this.availableSeconds <= 0) {
@@ -170,6 +182,7 @@ export class UsageSession {
     this.plannedSeconds = 0;
     this.availableSeconds = 0;
     this.render();
+    this.options.onFinished?.();
     void this.persistPending().then(() => {
       if (this.state === "hard-end") this.options.onHardLimitReached();
     });
@@ -205,5 +218,10 @@ export class UsageSession {
       this.environment.clearInterval(this.interval);
       this.interval = undefined;
     }
+  }
+
+  private checkpoint(): void {
+    if (this.state !== "running" || this.plannedSeconds <= 0) return;
+    this.options.onCheckpoint?.(this.plannedSeconds);
   }
 }

--- a/tests/lifecycle.integration.test.ts
+++ b/tests/lifecycle.integration.test.ts
@@ -11,11 +11,14 @@ import {
   localDateKey,
 } from "../lib/models";
 import {
+  clearActiveSession,
   dailyStateItem,
   dailyUsageStateItem,
   addUsageSeconds,
+  getActiveSession,
   getDailyUsageState,
   reserveAllowance,
+  saveActiveSession,
   settingsItem,
   usageHistoryItem,
 } from "../lib/storage";
@@ -110,7 +113,9 @@ describe("extension lifecycle integration", () => {
     vi.spyOn(fakeBrowser.runtime, "sendMessage").mockImplementation(
       ((message: unknown) =>
         Promise.resolve(
-          handleMessage(message, {} as RuntimeMessageSender),
+          handleMessage(message, {
+            tab: { id: 73 },
+          } as RuntimeMessageSender),
         )) as typeof fakeBrowser.runtime.sendMessage,
     );
     await settingsItem.setValue({
@@ -221,6 +226,81 @@ describe("extension lifecycle integration", () => {
     expect(
       (await dailyUsageStateItem.getValue()).usedSecondsByPlatform.reddit,
     ).toBe(5);
+  });
+
+  it("restores the active countdown after a document reload", async () => {
+    const date = localDateKey();
+    const firstTab = new FakeTabLifecycle();
+    const firstSession = new UsageSession(
+      {
+        platform: "reddit",
+        platformLabel: "Reddit",
+        plannedSeconds: 60,
+        availableSeconds: 300,
+        ui: createUi(),
+        onCheckpoint(plannedSeconds) {
+          void saveActiveSession({
+            platform: "reddit",
+            date,
+            plannedSeconds,
+          });
+        },
+        onFinished() {
+          void clearActiveSession("reddit");
+        },
+        onPlannedTimeElapsed: vi.fn(),
+        onHardLimitReached: vi.fn(),
+      },
+      firstTab,
+    );
+    firstSession.start();
+    firstTab.advance(3);
+    await firstSession.destroy();
+
+    await vi.waitFor(async () => {
+      expect(await getActiveSession("reddit")).toEqual({
+        platform: "reddit",
+        date,
+        plannedSeconds: 57,
+      });
+    });
+
+    const storedSession = await getActiveSession("reddit");
+    expect(storedSession).not.toBeNull();
+    const plannedTimeElapsed = vi.fn();
+    const reloadedTab = new FakeTabLifecycle();
+    const reloadedSession = new UsageSession(
+      {
+        platform: "reddit",
+        platformLabel: "Reddit",
+        plannedSeconds: storedSession?.plannedSeconds ?? 1,
+        availableSeconds: 297,
+        ui: createUi(),
+        onCheckpoint(plannedSeconds) {
+          void saveActiveSession({
+            platform: "reddit",
+            date,
+            plannedSeconds,
+          });
+        },
+        onFinished() {
+          void clearActiveSession("reddit");
+        },
+        onPlannedTimeElapsed: plannedTimeElapsed,
+        onHardLimitReached: vi.fn(),
+      },
+      reloadedTab,
+    );
+    reloadedSession.start();
+    reloadedTab.advance(56);
+    expect(plannedTimeElapsed).not.toHaveBeenCalled();
+    reloadedTab.advance(1);
+
+    await vi.waitFor(async () => {
+      expect(await getActiveSession("reddit")).toBeNull();
+      expect(plannedTimeElapsed).toHaveBeenCalledOnce();
+    });
+    await reloadedSession.destroy();
   });
 
   it("pauses while hidden and persists on visibility loss and page hide", async () => {

--- a/tests/runtime-messages.test.ts
+++ b/tests/runtime-messages.test.ts
@@ -10,6 +10,22 @@ describe("runtime messages", () => {
         elapsedSeconds: 5,
       }),
     ).toBe(true);
+    expect(
+      isRuntimeMessage({
+        type: "dopamine-fast:set-active-session",
+        session: {
+          platform: "instagram",
+          date: "2026-08-16",
+          plannedSeconds: 240,
+        },
+      }),
+    ).toBe(true);
+    expect(
+      isRuntimeMessage({
+        type: "dopamine-fast:get-active-session",
+        platform: "reddit",
+      }),
+    ).toBe(true);
     expect(isRuntimeMessage({ type: "dopamine-fast:leave-feed" })).toBe(true);
     expect(
       isRuntimeMessage({
@@ -37,5 +53,15 @@ describe("runtime messages", () => {
       }),
     ).toBe(false);
     expect(isRuntimeMessage({ type: "dopamine-fast:unknown" })).toBe(false);
+    expect(
+      isRuntimeMessage({
+        type: "dopamine-fast:set-active-session",
+        session: {
+          platform: "reddit",
+          date: "today",
+          plannedSeconds: 0,
+        },
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- checkpoint the active planned countdown in extension session storage per tab and network
- restore that countdown after full document navigation, reconcile it with the remaining daily allowance, and avoid reopening the time picker
- clear the checkpoint when the countdown finishes, protection is disabled, the network is disabled, the active schedule ends, or the tab closes
- preserve the active session when unrelated settings changes trigger content-script reactivation

## Root cause

Same-document SPA and history navigation already kept the in-memory `UsageSession`, but some post-to-home transitions reload the document. That discarded the session and made the opening duration picker appear again.

## Validation

- `npm run validate` — 61 tests, typecheck, Firefox build, Chrome build
- `npm run zip` — Firefox and Chrome packages generated
- `git diff --check`
- rebased onto the current `main`, including per-network limit schedules

## Manual testing

- [ ] Start a timed session, open a post that performs a full navigation, then return home in the same tab; the existing countdown should resume without asking for a duration.
- [ ] Let the countdown finish; the session-ended prompt should appear once and a new duration may be chosen.
- [ ] Close the tab, disable protection, disable the network or leave its active schedule; no active countdown should be restored.

## Scope

This PR is based on the current `main`. It does not add permissions, remote data handling, or new supported routes.