### PR TITLE
feat(schedule): add blocked hours and passive floating timer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,9 @@ Specific responsibilities:
   markup.
 - `intervention-ui.ts` owns rendering and direct UI interaction, not storage or
   platform detection.
+- The floating usage timer is informational, translucent and pointer-transparent.
+  Full-screen interventions remain interactive and inaccessible host-page
+  content must stay behind them.
 
 `intervention-ui.ts` is already the largest module. When adding another
 substantial screen or interaction state, split it by intervention or introduce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,11 @@ behavior, call out the discrepancy rather than silently choosing one.
 
 ## Current feature model
 
-On a supported feed route, the content script:
+On every supported route, the content script first resolves the network's
+optional access-block schedule. An active blocked window supersedes all other
+behavior and makes every route on that network unavailable.
+
+On a supported feed route outside blocked hours, the content script:
 
 1. Loads sanitized settings and the current local-day usage state.
 2. Stops immediately when the extension/site is disabled or the route is not a
@@ -94,6 +98,9 @@ Post counters and time budgets are independent per network:
 - `Settings.limitSchedule` stores the optional global weekly window plus each
   platform's global, custom or always-active mode. Schedule changes apply on
   reactivation, and clock boundaries are detected by the content lifecycle.
+- `Settings.accessBlockSchedule` stores independent global or per-platform
+  blocked hours. Each platform may inherit the global schedule, use a custom
+  schedule or opt out of complete blocking.
 - Active planned countdowns are checkpointed in extension session storage by
   tab and platform so full same-tab navigations do not reopen the initial time
   picker. They are cleared when the countdown ends, protection is disabled or
@@ -253,9 +260,9 @@ When adding or changing a platform:
 6. Manually test signed-in mobile and desktop layouts where available.
 7. Document the tested browser, viewport and network in the PR.
 
-Direct profiles, messages, settings and post-detail routes should remain
-usable and outside the limiter unless the product specification explicitly
-changes.
+Direct profiles, messages, settings and post-detail routes should remain usable
+and outside the limiter except while their network's explicit access-block
+schedule is active.
 
 ## DOM, privacy and security rules
 

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -81,6 +81,22 @@ Keep the useful parts of social networks while giving every feed a real end.
 - Schedules use the browser's local clock and are stored only in extension
   local storage.
 
+## Access-block schedules
+
+- Access blocking is independent from limit scheduling and is disabled by
+  default for backward compatibility.
+- A global blocked-hours schedule can be inherited by each network. A network
+  may instead use custom blocked days and hours or opt out of complete blocking.
+- During blocked hours, every route on that network is unavailable, including
+  feeds, individual posts or videos, profiles, messages and site settings.
+- A full-screen intervention offers only leaving the network or opening
+  Dopamine Fast settings; it exposes no temporary unlock or snooze action.
+- Access blocking takes priority over session, daily-time, feed and
+  suggestion-suppression behavior. Entering a blocked window ends and clears
+  any active planned session for that network.
+- Start, end, overnight and local-clock semantics match limit schedules.
+  Crossing either boundary applies without a page reload.
+
 ## Unlock flow
 
 The end of a batch is rendered inside the native feed. The inline control waits
@@ -118,6 +134,7 @@ visible area while the batch is closed.
 - Hide Reddit's Popular, News and Explore navigation shortcuts while suggested
   content blocking is enabled.
 - Limit listing pages to the active batch.
+- Block every Reddit route when its access-block schedule is active.
 
 ### X
 
@@ -132,6 +149,7 @@ visible area while the batch is closed.
 - Hide the result-category tabs and discovery sidebar after a submitted X
   search, leaving only the query and its results.
 - Limit the timeline to the active batch.
+- Block every X route when its access-block schedule is active.
 
 ### Instagram
 
@@ -149,6 +167,7 @@ visible area while the batch is closed.
   vertical wheel, keyboard and touch navigation to another reel.
 - Stop after the active batch or after Instagram's own caught-up marker,
   whichever comes first.
+- Block every Instagram route when its access-block schedule is active.
 
 ### YouTube
 
@@ -162,6 +181,7 @@ visible area while the batch is closed.
 - Always hide next-video, related-video, Shorts and end-screen recommendation
   surfaces on requested video pages.
 - Treat YouTube post and time budgets independently from every other network.
+- Block every YouTube route when its access-block schedule is active.
 
 ## Privacy and permissions
 

--- a/PRODUCT_SPEC.md
+++ b/PRODUCT_SPEC.md
@@ -41,7 +41,8 @@ Keep the useful parts of social networks while giving every feed a real end.
   daily time for the current network. Once a session starts, the counter and
   the chosen block survive same-network SPA navigation, browser history changes
   and full document reloads in the same tab instead of showing the opening
-  screen again.
+  screen again. The counter is translucent and pointer-transparent so it never
+  covers or captures interaction with the network underneath it.
 - Time advances only while the tab is visible.
 - When planned time ends, the user can leave or deliberately plan another
   block after a 10-second pause. The next duration cannot be selected until

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ available while adding deliberate friction around habitual scrolling:
 7. A per-network daily time ceiling cannot be extended from the page.
 8. Weekly schedules decide when those limits are active, globally or per
    network.
+9. Separate blocked-hours schedules can make an entire network unavailable.
 
 Daily post counts and time ceilings are tracked independently for Reddit,
 X/Twitter, Instagram, and YouTube. Post counts do not impose a maximum: every
@@ -83,6 +84,8 @@ hold before the next finite batch is revealed.
 - Separately configurable, non-extendable daily time ceiling for each network.
 - Optional weekly limit schedule with a global default and per-network custom
   hours, days or always-active override.
+- Optional blocked-hours schedule with a global default and per-network custom
+  hours, days or never-block override. It blocks every route on the network.
 - Finite initial and additional post batches with unlimited successive unlocks.
 - Stable per-session post counting for virtualized feeds such as Reddit.
 - Optional delay and press-and-hold step before revealing another batch.
@@ -93,17 +96,18 @@ hold before the next finite batch is revealed.
 
 ## Supported networks
 
-| Network | Feed limiting | Suggested-content suppression | Daily time ceiling | Schedule |
-| --- | --- | --- | --- | --- |
-| Reddit | Yes | Best effort | Independent | Global or custom |
-| X / Twitter | Yes | Best effort | Independent | Global or custom |
-| Instagram | Yes | Best effort | Independent | Global or custom |
-| YouTube | Yes | Best effort | Independent | Global or custom |
+| Network | Feed limiting | Suggested-content suppression | Daily ceiling | Limit hours | Blocked hours |
+| --- | --- | --- | --- | --- | --- |
+| Reddit | Yes | Best effort | Independent | Global or custom | Global, custom or never |
+| X / Twitter | Yes | Best effort | Independent | Global or custom | Global, custom or never |
+| Instagram | Yes | Best effort | Independent | Global or custom | Global, custom or never |
+| YouTube | Yes | Best effort | Independent | Global or custom | Global, custom or never |
 
 The limiter applies only to recognized feed routes. Direct profiles, messages,
-settings, and individual post pages are intended to remain available. Platform
-DOM changes may temporarily reduce detection accuracy; when confidence is low,
-the extension is designed to avoid hiding broad page containers.
+settings, and individual post pages remain available outside configured blocked
+hours. During blocked hours, the whole supported network is unavailable.
+Platform DOM changes may temporarily reduce detection accuracy; when confidence
+is low, the extension is designed to avoid hiding broad page containers.
 
 ## Install for development
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ hold before the next finite batch is revealed.
   intervention load, preventing clicks or scrolling through the feed first.
 - Per-network intentional session duration, adjusted through deliberate button
   steps, with a floating countdown that remains active across same-network SPA,
-  history navigation and full document reloads in the same tab.
+  history navigation and full document reloads in the same tab. The countdown
+  is translucent and click-through, so content underneath remains usable.
 - Optional Following-only modes for X and Instagram that select followed
   content while keeping direct profiles available.
 - Intentional search on X, Instagram and Reddit: autocomplete or default

--- a/assets/content.css
+++ b/assets/content.css
@@ -40,6 +40,10 @@
   animation: df-backdrop-in 180ms ease-out both;
 }
 
+.df-backdrop--access-blocked {
+  touch-action: none;
+}
+
 .df-card {
   position: relative;
   display: flex;

--- a/assets/content.css
+++ b/assets/content.css
@@ -24,6 +24,7 @@
   z-index: 2147483646;
   right: max(12px, env(safe-area-inset-right));
   bottom: max(72px, calc(env(safe-area-inset-bottom) + 64px));
+  pointer-events: none;
 }
 
 .df-backdrop {
@@ -335,15 +336,14 @@
   min-width: 142px;
   align-items: center;
   padding: 9px 12px;
-  border: 1px solid rgba(240, 241, 237, 0.28);
+  border: 1px solid rgba(240, 241, 237, 0.2);
   border-radius: 2px;
   color: #f0f1ed;
-  background: rgba(21, 23, 22, 0.96);
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.28);
+  background: rgba(21, 23, 22, 0.58);
+  box-shadow: 0 6px 22px rgba(0, 0, 0, 0.16);
   font: inherit;
   text-align: left;
-  backdrop-filter: blur(12px);
-  cursor: pointer;
+  backdrop-filter: blur(5px);
 }
 
 .df-usage-timer__pulse {
@@ -379,7 +379,7 @@
 .df-usage-timer[data-urgent="true"] {
   border-color: #929a94;
   color: #f0f1ed;
-  background: #252927;
+  background: rgba(37, 41, 39, 0.68);
 }
 
 .df-usage-timer[data-urgent="true"] small {

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -2,7 +2,10 @@ import "../assets/content.css";
 import { FeedLimiter } from "../lib/feed-limiter";
 import { InterventionUi } from "../lib/intervention-ui";
 import { IntentionalSearchController } from "../lib/intentional-search";
-import { areLimitsActive } from "../lib/limit-schedule";
+import {
+  areLimitsActive,
+  isAccessBlocked,
+} from "../lib/limit-schedule";
 import {
   availableUsageSeconds,
   localDateKey,
@@ -27,6 +30,8 @@ import {
 import { usageForDate } from "../lib/usage-history";
 import { UsageSession } from "../lib/usage-session";
 
+const ACCESS_BLOCK_GUARD_OWNER = -1;
+
 export default defineContentScript({
   matches: [
     "*://reddit.com/*",
@@ -46,10 +51,13 @@ export default defineContentScript({
     const adapter = getPlatformAdapter(location.hostname);
     if (!adapter) return;
 
-    const interactionGuard = new PageInteractionGuard();
-    if (adapter.isFeedRoute(new URL(location.href))) {
-      interactionGuard.engage(0);
-    }
+    let interventionRoot: HTMLElement | undefined;
+    const interactionGuard = new PageInteractionGuard(window, (event) =>
+      interventionRoot
+        ? event.composedPath().includes(interventionRoot)
+        : false,
+    );
+    interactionGuard.engage(0);
     ctx.onInvalidated(() => interactionGuard.destroy());
 
     if (document.readyState === "loading") {
@@ -70,6 +78,7 @@ export default defineContentScript({
         const root = document.createElement("div");
         root.className = "df-root";
         container.append(root);
+        interventionRoot = root;
         return new InterventionUi(root);
       },
       onRemove(ui) {
@@ -103,21 +112,16 @@ export default defineContentScript({
     let currentUrl = "";
     let activationId = 0;
     let currentSettings: Settings | undefined;
+    let accessIsBlocked: boolean | undefined;
     let limitsAreActive: boolean | undefined;
 
     const activate = (preserveUsageSession = false): Promise<void> => {
       const thisActivation = ++activationId;
       currentSettings = undefined;
+      accessIsBlocked = undefined;
       limitsAreActive = undefined;
       const url = new URL(location.href);
-      if (
-        adapter.isFeedRoute(url) &&
-        (!preserveUsageSession || !usageSession)
-      ) {
-        interactionGuard.engage(thisActivation);
-      } else {
-        interactionGuard.releaseAll();
-      }
+      interactionGuard.engage(thisActivation);
 
       return (async () => {
       if (limiter) sessionPostAllowance = limiter.getAllowance();
@@ -155,6 +159,20 @@ export default defineContentScript({
         await previousUsageSession?.destroy();
         await clearActiveSession(adapter.id);
         intervention.hideAll();
+        return;
+      }
+
+      accessIsBlocked = isAccessBlocked(settings, adapter.id);
+      if (accessIsBlocked) {
+        const previousUsageSession = usageSession;
+        usageSession = undefined;
+        usageSessionNeedsAllowance = false;
+        sessionPostAllowance = 0;
+        await previousUsageSession?.destroy();
+        await clearActiveSession(adapter.id);
+        if (thisActivation !== activationId) return;
+        intervention.showAccessBlocked(adapter.label);
+        interactionGuard.engage(ACCESS_BLOCK_GUARD_OWNER);
         return;
       }
 
@@ -388,7 +406,16 @@ export default defineContentScript({
         void activate(true);
         return;
       }
-      if (!currentSettings || limitsAreActive === undefined) return;
+      if (!currentSettings || accessIsBlocked === undefined) return;
+      const nextAccessIsBlocked = isAccessBlocked(
+        currentSettings,
+        adapter.id,
+      );
+      if (nextAccessIsBlocked !== accessIsBlocked) {
+        void activate();
+        return;
+      }
+      if (accessIsBlocked || limitsAreActive === undefined) return;
       const nextLimitsAreActive = areLimitsActive(
         currentSettings,
         adapter.id,

--- a/entrypoints/options/index.html
+++ b/entrypoints/options/index.html
@@ -23,7 +23,7 @@
           <label class="master-toggle">
             <span>
               <strong>Protection enabled</strong>
-              <small>Pause and limit supported feeds.</small>
+              <small>Limit feeds and enforce blocked hours.</small>
             </span>
             <input id="enabled" name="enabled" type="checkbox" />
             <span class="switch" aria-hidden="true"></span>
@@ -35,12 +35,16 @@
           <div class="section-heading">
             <h2>Global schedule</h2>
             <p>
-              Choose when limits are active by default. Networks can inherit
-              this schedule or override it below.
+              Set default hours for normal limits and complete access blocks.
+              Networks can inherit or override both schedules below.
             </p>
           </div>
 
           <div class="schedule-card">
+            <div class="schedule-card__heading">
+              <strong>Limit hours</strong>
+              <small>Sessions, daily time and finite batches apply in this window.</small>
+            </div>
             <label class="schedule-toggle">
               <span>
                 <strong>Use a global schedule</strong>
@@ -72,13 +76,44 @@
               <p class="schedule-hint">If the end is earlier than the start, the window continues overnight. Matching times cover the full selected day.</p>
             </div>
           </div>
+
+          <div class="schedule-card schedule-card--blocked">
+            <div class="schedule-card__heading">
+              <strong>Blocked hours</strong>
+              <small>Every page on inherited networks is completely unavailable.</small>
+            </div>
+            <label class="schedule-toggle">
+              <span>
+                <strong>Use global blocked hours</strong>
+                <small>When off, inherited networks are never fully blocked.</small>
+              </span>
+              <input id="global-block-schedule-enabled" type="checkbox" />
+            </label>
+            <div id="global-block-schedule-fields" class="schedule-fields">
+              <div class="time-range">
+                <label><span>From</span><input id="global-block-schedule-start" type="time" /></label>
+                <label><span>To</span><input id="global-block-schedule-end" type="time" /></label>
+              </div>
+              <fieldset class="day-picker">
+                <legend>Blocked days</legend>
+                <label><input type="checkbox" data-schedule-day="global-block" value="monday" /><span>Mon</span></label>
+                <label><input type="checkbox" data-schedule-day="global-block" value="tuesday" /><span>Tue</span></label>
+                <label><input type="checkbox" data-schedule-day="global-block" value="wednesday" /><span>Wed</span></label>
+                <label><input type="checkbox" data-schedule-day="global-block" value="thursday" /><span>Thu</span></label>
+                <label><input type="checkbox" data-schedule-day="global-block" value="friday" /><span>Fri</span></label>
+                <label><input type="checkbox" data-schedule-day="global-block" value="saturday" /><span>Sat</span></label>
+                <label><input type="checkbox" data-schedule-day="global-block" value="sunday" /><span>Sun</span></label>
+              </fieldset>
+              <p class="schedule-hint">Blocked hours override limit hours and include feeds, posts, profiles, messages and settings on the network.</p>
+            </div>
+          </div>
         </section>
 
         <section class="panel">
           <div class="section-number">02</div>
           <div class="section-heading">
             <h2>Networks</h2>
-            <p>Each network keeps its activation, time budget and schedule together.</p>
+            <p>Each network keeps its activation, time budget, limit hours and blocked hours together.</p>
           </div>
 
           <div class="network-grid">
@@ -107,6 +142,15 @@
                     <label><input type="checkbox" data-schedule-day="reddit" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="reddit" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="reddit" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="reddit" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="reddit" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="reddit" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="reddit" value="sunday" /><span>Sun</span></label>
                   </fieldset>
                 </div>
+                <div class="network-block-schedule">
+                  <label class="select-field"><span>Blocked hours</span><select id="reddit-block-schedule-mode"><option value="global">Use global blocked hours</option><option value="custom">Custom blocked hours</option><option value="never">Never fully block</option></select></label>
+                  <div id="reddit-block-schedule-fields" class="schedule-fields schedule-fields--network schedule-fields--blocked">
+                    <div class="time-range"><label><span>From</span><input id="reddit-block-schedule-start" type="time" /></label><label><span>To</span><input id="reddit-block-schedule-end" type="time" /></label></div>
+                    <fieldset class="day-picker"><legend>Blocked days</legend>
+                      <label><input type="checkbox" data-schedule-day="reddit-block" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="reddit-block" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="reddit-block" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="reddit-block" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="reddit-block" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="reddit-block" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="reddit-block" value="sunday" /><span>Sun</span></label>
+                    </fieldset>
+                  </div>
+                </div>
               </div>
             </article>
 
@@ -134,6 +178,15 @@
                   <fieldset class="day-picker"><legend>Active days</legend>
                     <label><input type="checkbox" data-schedule-day="x" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="x" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="x" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="x" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="x" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="x" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="x" value="sunday" /><span>Sun</span></label>
                   </fieldset>
+                </div>
+                <div class="network-block-schedule">
+                  <label class="select-field"><span>Blocked hours</span><select id="x-block-schedule-mode"><option value="global">Use global blocked hours</option><option value="custom">Custom blocked hours</option><option value="never">Never fully block</option></select></label>
+                  <div id="x-block-schedule-fields" class="schedule-fields schedule-fields--network schedule-fields--blocked">
+                    <div class="time-range"><label><span>From</span><input id="x-block-schedule-start" type="time" /></label><label><span>To</span><input id="x-block-schedule-end" type="time" /></label></div>
+                    <fieldset class="day-picker"><legend>Blocked days</legend>
+                      <label><input type="checkbox" data-schedule-day="x-block" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="x-block" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="x-block" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="x-block" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="x-block" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="x-block" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="x-block" value="sunday" /><span>Sun</span></label>
+                    </fieldset>
+                  </div>
                 </div>
                 <label class="card-option"><span><strong>Following only</strong><small>Prefer Following and hide For You.</small></span><input id="x-following-only" type="checkbox" /></label>
               </div>
@@ -164,6 +217,15 @@
                     <label><input type="checkbox" data-schedule-day="instagram" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="instagram" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="instagram" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="instagram" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="instagram" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="instagram" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="instagram" value="sunday" /><span>Sun</span></label>
                   </fieldset>
                 </div>
+                <div class="network-block-schedule">
+                  <label class="select-field"><span>Blocked hours</span><select id="instagram-block-schedule-mode"><option value="global">Use global blocked hours</option><option value="custom">Custom blocked hours</option><option value="never">Never fully block</option></select></label>
+                  <div id="instagram-block-schedule-fields" class="schedule-fields schedule-fields--network schedule-fields--blocked">
+                    <div class="time-range"><label><span>From</span><input id="instagram-block-schedule-start" type="time" /></label><label><span>To</span><input id="instagram-block-schedule-end" type="time" /></label></div>
+                    <fieldset class="day-picker"><legend>Blocked days</legend>
+                      <label><input type="checkbox" data-schedule-day="instagram-block" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="instagram-block" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="instagram-block" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="instagram-block" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="instagram-block" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="instagram-block" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="instagram-block" value="sunday" /><span>Sun</span></label>
+                    </fieldset>
+                  </div>
+                </div>
                 <label class="card-option"><span><strong>Following only</strong><small>Open Following and hide For You.</small></span><input id="instagram-following-only" type="checkbox" /></label>
               </div>
             </article>
@@ -193,6 +255,15 @@
                     <label><input type="checkbox" data-schedule-day="youtube" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="youtube" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="youtube" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="youtube" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="youtube" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="youtube" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="youtube" value="sunday" /><span>Sun</span></label>
                   </fieldset>
                 </div>
+                <div class="network-block-schedule">
+                  <label class="select-field"><span>Blocked hours</span><select id="youtube-block-schedule-mode"><option value="global">Use global blocked hours</option><option value="custom">Custom blocked hours</option><option value="never">Never fully block</option></select></label>
+                  <div id="youtube-block-schedule-fields" class="schedule-fields schedule-fields--network schedule-fields--blocked">
+                    <div class="time-range"><label><span>From</span><input id="youtube-block-schedule-start" type="time" /></label><label><span>To</span><input id="youtube-block-schedule-end" type="time" /></label></div>
+                    <fieldset class="day-picker"><legend>Blocked days</legend>
+                      <label><input type="checkbox" data-schedule-day="youtube-block" value="monday" /><span>Mon</span></label><label><input type="checkbox" data-schedule-day="youtube-block" value="tuesday" /><span>Tue</span></label><label><input type="checkbox" data-schedule-day="youtube-block" value="wednesday" /><span>Wed</span></label><label><input type="checkbox" data-schedule-day="youtube-block" value="thursday" /><span>Thu</span></label><label><input type="checkbox" data-schedule-day="youtube-block" value="friday" /><span>Fri</span></label><label><input type="checkbox" data-schedule-day="youtube-block" value="saturday" /><span>Sat</span></label><label><input type="checkbox" data-schedule-day="youtube-block" value="sunday" /><span>Sun</span></label>
+                    </fieldset>
+                  </div>
+                </div>
                 <label class="card-option"><span><strong>Subscriptions only</strong><small>Redirect Home to Subscriptions.</small></span><input id="youtube-subscriptions-only" type="checkbox" /></label>
               </div>
             </article>
@@ -200,7 +271,7 @@
         </section>
 
         <section class="panel">
-          <div class="section-number">04</div>
+          <div class="section-number">03</div>
           <div class="section-heading">
             <h2>Entry pace</h2>
             <p>Add a pause before opening a feed.</p>
@@ -234,7 +305,7 @@
         </section>
 
         <section class="panel">
-          <div class="section-number">03</div>
+          <div class="section-number">04</div>
           <div class="section-heading">
             <h2>Feed size</h2>
             <p>Every batch truly ends. You decide whether to open another.</p>

--- a/entrypoints/options/main.ts
+++ b/entrypoints/options/main.ts
@@ -1,6 +1,7 @@
 import "./style.css";
 import {
   sanitizeSettings,
+  type AccessBlockScheduleMode,
   type LimitScheduleMode,
   type PlatformId,
   type Settings,
@@ -26,6 +27,12 @@ const controls = {
   ),
   globalScheduleFields: requiredElement<HTMLElement>(
     "#global-schedule-fields",
+  ),
+  globalBlockScheduleEnabled: requiredElement<HTMLInputElement>(
+    "#global-block-schedule-enabled",
+  ),
+  globalBlockScheduleFields: requiredElement<HTMLElement>(
+    "#global-block-schedule-fields",
   ),
   unlockDelay: requiredElement<HTMLInputElement>("#unlock-delay"),
   unlockDelayOutput:
@@ -62,11 +69,18 @@ interface NetworkControls {
   dailyUsageLimit: HTMLInputElement;
   scheduleMode: HTMLSelectElement;
   schedule: ScheduleControls;
+  blockScheduleMode: HTMLSelectElement;
+  blockSchedule: ScheduleControls;
 }
 
 const globalScheduleControls: ScheduleControls = createScheduleControls(
   "global",
   controls.globalScheduleFields,
+);
+
+const globalBlockScheduleControls: ScheduleControls = createScheduleControls(
+  "global-block",
+  controls.globalBlockScheduleFields,
 );
 
 const networkControls: Record<
@@ -78,24 +92,32 @@ const networkControls: Record<
     dailyUsageLimit: requiredElement("#reddit-daily-usage-limit"),
     scheduleMode: requiredElement("#reddit-schedule-mode"),
     schedule: createScheduleControls("reddit"),
+    blockScheduleMode: requiredElement("#reddit-block-schedule-mode"),
+    blockSchedule: createScheduleControls("reddit-block"),
   },
   x: {
     sessionDuration: requiredElement("#x-session-duration"),
     dailyUsageLimit: requiredElement("#x-daily-usage-limit"),
     scheduleMode: requiredElement("#x-schedule-mode"),
     schedule: createScheduleControls("x"),
+    blockScheduleMode: requiredElement("#x-block-schedule-mode"),
+    blockSchedule: createScheduleControls("x-block"),
   },
   instagram: {
     sessionDuration: requiredElement("#instagram-session-duration"),
     dailyUsageLimit: requiredElement("#instagram-daily-usage-limit"),
     scheduleMode: requiredElement("#instagram-schedule-mode"),
     schedule: createScheduleControls("instagram"),
+    blockScheduleMode: requiredElement("#instagram-block-schedule-mode"),
+    blockSchedule: createScheduleControls("instagram-block"),
   },
   youtube: {
     sessionDuration: requiredElement("#youtube-session-duration"),
     dailyUsageLimit: requiredElement("#youtube-daily-usage-limit"),
     scheduleMode: requiredElement("#youtube-schedule-mode"),
     schedule: createScheduleControls("youtube"),
+    blockScheduleMode: requiredElement("#youtube-block-schedule-mode"),
+    blockSchedule: createScheduleControls("youtube-block"),
   },
 };
 
@@ -106,7 +128,7 @@ function requiredElement<T extends Element>(selector: string): T {
 }
 
 function createScheduleControls(
-  scope: "global" | PlatformId,
+  scope: "global" | "global-block" | PlatformId | `${PlatformId}-block`,
   fields = requiredElement<HTMLElement>(`#${scope}-schedule-fields`),
 ): ScheduleControls {
   const day = (weekday: WeekdayId) =>
@@ -141,6 +163,12 @@ function render(settings: Settings): void {
   controls.globalScheduleEnabled.checked =
     settings.limitSchedule.globalEnabled;
   renderSchedule(globalScheduleControls, settings.limitSchedule.global);
+  controls.globalBlockScheduleEnabled.checked =
+    settings.accessBlockSchedule.globalEnabled;
+  renderSchedule(
+    globalBlockScheduleControls,
+    settings.accessBlockSchedule.global,
+  );
   for (const platform of Object.keys(networkControls) as PlatformId[]) {
     networkControls[platform].sessionDuration.value = String(
       settings.sessionDurationMinutesByPlatform[platform],
@@ -153,6 +181,12 @@ function render(settings: Settings): void {
     renderSchedule(
       networkControls[platform].schedule,
       settings.limitSchedule.byPlatform[platform],
+    );
+    networkControls[platform].blockScheduleMode.value =
+      settings.accessBlockSchedule.modeByPlatform[platform];
+    renderSchedule(
+      networkControls[platform].blockSchedule,
+      settings.accessBlockSchedule.byPlatform[platform],
     );
   }
   controls.unlockDelay.value = String(settings.unlockDelaySeconds);
@@ -202,9 +236,13 @@ function readSchedule(scheduleControls: ScheduleControls): WeeklyLimitSchedule {
 function updateScheduleVisibility(): void {
   controls.globalScheduleFields.hidden =
     !controls.globalScheduleEnabled.checked;
+  controls.globalBlockScheduleFields.hidden =
+    !controls.globalBlockScheduleEnabled.checked;
   for (const platform of Object.keys(networkControls) as PlatformId[]) {
     networkControls[platform].schedule.fields.hidden =
       networkControls[platform].scheduleMode.value !== "custom";
+    networkControls[platform].blockSchedule.fields.hidden =
+      networkControls[platform].blockScheduleMode.value !== "custom";
   }
 }
 
@@ -257,6 +295,26 @@ function readSettings(): Settings {
         youtube: readSchedule(networkControls.youtube.schedule),
       },
     },
+    accessBlockSchedule: {
+      globalEnabled: controls.globalBlockScheduleEnabled.checked,
+      global: readSchedule(globalBlockScheduleControls),
+      modeByPlatform: {
+        reddit: networkControls.reddit.blockScheduleMode
+          .value as AccessBlockScheduleMode,
+        x: networkControls.x.blockScheduleMode
+          .value as AccessBlockScheduleMode,
+        instagram: networkControls.instagram.blockScheduleMode
+          .value as AccessBlockScheduleMode,
+        youtube: networkControls.youtube.blockScheduleMode
+          .value as AccessBlockScheduleMode,
+      },
+      byPlatform: {
+        reddit: readSchedule(networkControls.reddit.blockSchedule),
+        x: readSchedule(networkControls.x.blockSchedule),
+        instagram: readSchedule(networkControls.instagram.blockSchedule),
+        youtube: readSchedule(networkControls.youtube.blockSchedule),
+      },
+    },
   });
 }
 
@@ -268,8 +326,16 @@ controls.globalScheduleEnabled.addEventListener(
   "change",
   updateScheduleVisibility,
 );
+controls.globalBlockScheduleEnabled.addEventListener(
+  "change",
+  updateScheduleVisibility,
+);
 for (const platform of Object.keys(networkControls) as PlatformId[]) {
   networkControls[platform].scheduleMode.addEventListener(
+    "change",
+    updateScheduleVisibility,
+  );
+  networkControls[platform].blockScheduleMode.addEventListener(
     "change",
     updateScheduleVisibility,
   );

--- a/entrypoints/options/style.css
+++ b/entrypoints/options/style.css
@@ -5,6 +5,8 @@
   --ink: #182018;
   --muted: #687067;
   --acid: #cfff00;
+  --blocked: #983b35;
+  --blocked-soft: rgba(152, 59, 53, 0.08);
   --line: rgba(24, 32, 24, 0.2);
   font-family: "Avenir Next", "Gill Sans", "Trebuchet MS", sans-serif;
   color: var(--ink);
@@ -155,6 +157,32 @@ select {
   padding: 18px;
   border: 1px solid var(--line);
   background: rgba(255, 255, 255, 0.3);
+}
+
+.schedule-card__heading {
+  display: grid;
+  gap: 2px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+}
+
+.schedule-card__heading strong {
+  font-family: "Iowan Old Style", "Palatino Linotype", serif;
+  font-size: 24px;
+  font-weight: 500;
+}
+
+.schedule-card__heading small {
+  color: var(--muted);
+}
+
+.schedule-card--blocked {
+  border-color: rgba(152, 59, 53, 0.48);
+  box-shadow: inset 4px 0 0 var(--blocked);
+}
+
+.schedule-card--blocked .schedule-card__heading strong {
+  color: var(--blocked);
 }
 
 .schedule-toggle,
@@ -328,6 +356,18 @@ select {
   padding: 14px;
   border-left: 3px solid var(--acid);
   background: rgba(24, 32, 24, 0.045);
+}
+
+.network-block-schedule {
+  display: grid;
+  gap: 10px;
+  padding-top: 16px;
+  border-top: 1px solid var(--line);
+}
+
+.schedule-fields--blocked {
+  border-left-color: var(--blocked);
+  background: var(--blocked-soft);
 }
 
 .card-option {

--- a/lib/intervention-ui.ts
+++ b/lib/intervention-ui.ts
@@ -1,6 +1,7 @@
 import type { RuntimeMessage } from "./runtime-messages";
 import { sessionMinuteChoices } from "./session-time";
 import {
+  createAccessBlockedView,
   createHardLimitView,
   createOpeningView,
   createSessionEndedView,
@@ -257,6 +258,38 @@ export class InterventionUi {
       .addEventListener("click", () => this.leaveFeed());
     this.requiredElement<HTMLButtonElement>('[data-action="settings"]')
       .addEventListener("click", () => this.openOptions());
+  }
+
+  showAccessBlocked(platformLabel: string): void {
+    const cancelPendingInteraction = this.cancelPendingInteraction;
+    this.cancelPendingInteraction = undefined;
+    cancelPendingInteraction?.();
+    this.hideUsageTimer();
+    this.overlay.replaceChildren(createAccessBlockedView(platformLabel));
+
+    const leaveButton =
+      this.requiredElement<HTMLButtonElement>('[data-action="leave"]');
+    const settingsButton =
+      this.requiredElement<HTMLButtonElement>('[data-action="settings"]');
+    leaveButton.addEventListener("click", () => this.leaveFeed());
+    settingsButton.addEventListener("click", () => this.openOptions());
+
+    const backdrop = this.requiredElement<HTMLElement>(".df-backdrop");
+    const focusable = [leaveButton, settingsButton];
+    backdrop.addEventListener("keydown", (event) => {
+      if (event.key !== "Tab") return;
+      const currentIndex = focusable.indexOf(event.target as HTMLButtonElement);
+      const nextIndex =
+        currentIndex === -1
+          ? event.shiftKey
+            ? focusable.length - 1
+            : 0
+          : (currentIndex + (event.shiftKey ? -1 : 1) + focusable.length) %
+            focusable.length;
+      event.preventDefault();
+      focusable[nextIndex]?.focus();
+    });
+    leaveButton.focus();
   }
 
   showUsageTimer(options: UsageTimerOptions): void {

--- a/lib/intervention-ui.ts
+++ b/lib/intervention-ui.ts
@@ -295,9 +295,6 @@ export class InterventionUi {
   showUsageTimer(options: UsageTimerOptions): void {
     if (this.timer.childElementCount === 0) {
       this.timer.replaceChildren(createUsageTimerView());
-      this.timer
-        .querySelector<HTMLButtonElement>(".df-usage-timer")
-        ?.addEventListener("click", () => this.openOptions());
     }
 
     const timer = this.timer.querySelector<HTMLElement>(".df-usage-timer");

--- a/lib/intervention-views.ts
+++ b/lib/intervention-views.ts
@@ -298,12 +298,12 @@ export function createAccessBlockedView(platformLabel: string): HTMLElement {
   );
 }
 
-export function createUsageTimerView(): HTMLButtonElement {
-  return element("button", {
+export function createUsageTimerView(): HTMLDivElement {
+  return element("div", {
     className: "df-usage-timer",
     attributes: {
-      type: "button",
-      title: "Open Dopamine Fast settings",
+      role: "status",
+      "aria-live": "polite",
     },
     children: [
       element("span", {

--- a/lib/intervention-views.ts
+++ b/lib/intervention-views.ts
@@ -259,6 +259,45 @@ export function createHardLimitView(platformLabel: string): HTMLElement {
   );
 }
 
+export function createAccessBlockedView(platformLabel: string): HTMLElement {
+  return dialog(
+    "df-access-block-title",
+    element("article", {
+      className: "df-card df-card--access-blocked",
+      children: [
+        element("div", {
+          className: "df-lock-mark",
+          attributes: { "aria-hidden": "true" },
+        }),
+        element("p", {
+          className: "df-kicker",
+          text: "Blocked hours",
+        }),
+        element("h1", {
+          text: `${platformLabel} is blocked right now.`,
+          attributes: { id: "df-access-block-title" },
+        }),
+        element("p", {
+          className: "df-copy",
+          text: "This schedule blocks every page on this network. Access returns when the blocked window ends.",
+        }),
+        element("div", {
+          className: "df-actions df-actions--stack",
+          children: [
+            actionButton(
+              `Leave ${platformLabel}`,
+              "leave",
+              "df-button df-button--primary",
+            ),
+          ],
+        }),
+        actionButton("View blocking schedule", "settings", "df-settings-link"),
+      ],
+    }),
+    "df-backdrop df-backdrop--access-blocked",
+  );
+}
+
 export function createUsageTimerView(): HTMLButtonElement {
   return element("button", {
     className: "df-usage-timer",
@@ -320,9 +359,13 @@ function timeStepper(
   });
 }
 
-function dialog(labelledBy: string, card: HTMLElement): HTMLElement {
+function dialog(
+  labelledBy: string,
+  card: HTMLElement,
+  className = "df-backdrop",
+): HTMLElement {
   return element("section", {
-    className: "df-backdrop",
+    className,
     attributes: {
       role: "dialog",
       "aria-modal": "true",

--- a/lib/limit-schedule.ts
+++ b/lib/limit-schedule.ts
@@ -31,6 +31,24 @@ export function areLimitsActive(
   return isWithinWeeklySchedule(schedule, date);
 }
 
+export function isAccessBlocked(
+  settings: Settings,
+  platform: PlatformId,
+  date = new Date(),
+): boolean {
+  const mode = settings.accessBlockSchedule.modeByPlatform[platform];
+  if (mode === "never") return false;
+  if (mode === "global" && !settings.accessBlockSchedule.globalEnabled) {
+    return false;
+  }
+
+  const schedule =
+    mode === "custom"
+      ? settings.accessBlockSchedule.byPlatform[platform]
+      : settings.accessBlockSchedule.global;
+  return isWithinWeeklySchedule(schedule, date);
+}
+
 export function isWithinWeeklySchedule(
   schedule: WeeklyLimitSchedule,
   date: Date,

--- a/lib/models.ts
+++ b/lib/models.ts
@@ -16,6 +16,8 @@ export type WeekdayId = (typeof WEEKDAY_IDS)[number];
 
 export type LimitScheduleMode = "global" | "custom" | "always";
 
+export type AccessBlockScheduleMode = "global" | "custom" | "never";
+
 export interface WeeklyLimitSchedule {
   startTime: string;
   endTime: string;
@@ -26,6 +28,13 @@ export interface LimitScheduleSettings {
   globalEnabled: boolean;
   global: WeeklyLimitSchedule;
   modeByPlatform: Record<PlatformId, LimitScheduleMode>;
+  byPlatform: Record<PlatformId, WeeklyLimitSchedule>;
+}
+
+export interface AccessBlockScheduleSettings {
+  globalEnabled: boolean;
+  global: WeeklyLimitSchedule;
+  modeByPlatform: Record<PlatformId, AccessBlockScheduleMode>;
   byPlatform: Record<PlatformId, WeeklyLimitSchedule>;
 }
 
@@ -45,6 +54,7 @@ export interface Settings {
   youtubeSubscriptionsOnly: boolean;
   enabledSites: Record<PlatformId, boolean>;
   limitSchedule: LimitScheduleSettings;
+  accessBlockSchedule: AccessBlockScheduleSettings;
 }
 
 export interface DailyState {
@@ -107,6 +117,22 @@ export const DEFAULT_SETTINGS: Settings = {
       youtube: createDefaultWeeklySchedule(),
     },
   },
+  accessBlockSchedule: {
+    globalEnabled: false,
+    global: createDefaultAccessBlockSchedule(),
+    modeByPlatform: {
+      reddit: "global",
+      x: "global",
+      instagram: "global",
+      youtube: "global",
+    },
+    byPlatform: {
+      reddit: createDefaultAccessBlockSchedule(),
+      x: createDefaultAccessBlockSchedule(),
+      instagram: createDefaultAccessBlockSchedule(),
+      youtube: createDefaultAccessBlockSchedule(),
+    },
+  },
 };
 
 type WeeklyLimitScheduleInput = {
@@ -122,17 +148,26 @@ type LimitScheduleSettingsInput = {
   byPlatform?: Partial<Record<PlatformId, WeeklyLimitScheduleInput>>;
 };
 
+type AccessBlockScheduleSettingsInput = {
+  globalEnabled?: unknown;
+  global?: WeeklyLimitScheduleInput;
+  modeByPlatform?: Partial<Record<PlatformId, unknown>>;
+  byPlatform?: Partial<Record<PlatformId, WeeklyLimitScheduleInput>>;
+};
+
 type SettingsInput = Partial<
   Omit<
     Settings,
     | "sessionDurationMinutesByPlatform"
     | "dailyUsageLimitMinutesByPlatform"
     | "limitSchedule"
+    | "accessBlockSchedule"
   >
 > & {
   sessionDurationMinutesByPlatform?: Partial<PlatformMinutes>;
   dailyUsageLimitMinutesByPlatform?: Partial<PlatformMinutes>;
   limitSchedule?: LimitScheduleSettingsInput;
+  accessBlockSchedule?: AccessBlockScheduleSettingsInput;
   sessionDurationMinutes?: number;
   dailyUsageLimitMinutes?: number;
 };
@@ -244,6 +279,9 @@ export function sanitizeSettings(input: SettingsInput): Settings {
       ),
     },
     limitSchedule: sanitizeLimitSchedule(input.limitSchedule),
+    accessBlockSchedule: sanitizeAccessBlockSchedule(
+      input.accessBlockSchedule,
+    ),
   };
 }
 
@@ -410,6 +448,14 @@ function createDefaultWeeklySchedule(): WeeklyLimitSchedule {
   };
 }
 
+function createDefaultAccessBlockSchedule(): WeeklyLimitSchedule {
+  return {
+    ...createDefaultWeeklySchedule(),
+    startTime: "22:00",
+    endTime: "07:00",
+  };
+}
+
 function sanitizeLimitSchedule(
   input: LimitScheduleSettingsInput | undefined,
 ): LimitScheduleSettings {
@@ -434,6 +480,55 @@ function sanitizeLimitSchedule(
         fallback.modeByPlatform.instagram,
       ),
       youtube: sanitizeScheduleMode(
+        input?.modeByPlatform?.youtube,
+        fallback.modeByPlatform.youtube,
+      ),
+    },
+    byPlatform: {
+      reddit: sanitizeWeeklySchedule(
+        input?.byPlatform?.reddit,
+        fallback.byPlatform.reddit,
+      ),
+      x: sanitizeWeeklySchedule(
+        input?.byPlatform?.x,
+        fallback.byPlatform.x,
+      ),
+      instagram: sanitizeWeeklySchedule(
+        input?.byPlatform?.instagram,
+        fallback.byPlatform.instagram,
+      ),
+      youtube: sanitizeWeeklySchedule(
+        input?.byPlatform?.youtube,
+        fallback.byPlatform.youtube,
+      ),
+    },
+  };
+}
+
+function sanitizeAccessBlockSchedule(
+  input: AccessBlockScheduleSettingsInput | undefined,
+): AccessBlockScheduleSettings {
+  const fallback = DEFAULT_SETTINGS.accessBlockSchedule;
+  return {
+    globalEnabled: sanitizeBoolean(
+      input?.globalEnabled,
+      fallback.globalEnabled,
+    ),
+    global: sanitizeWeeklySchedule(input?.global, fallback.global),
+    modeByPlatform: {
+      reddit: sanitizeAccessBlockScheduleMode(
+        input?.modeByPlatform?.reddit,
+        fallback.modeByPlatform.reddit,
+      ),
+      x: sanitizeAccessBlockScheduleMode(
+        input?.modeByPlatform?.x,
+        fallback.modeByPlatform.x,
+      ),
+      instagram: sanitizeAccessBlockScheduleMode(
+        input?.modeByPlatform?.instagram,
+        fallback.modeByPlatform.instagram,
+      ),
+      youtube: sanitizeAccessBlockScheduleMode(
         input?.modeByPlatform?.youtube,
         fallback.modeByPlatform.youtube,
       ),
@@ -492,6 +587,15 @@ function sanitizeScheduleMode(
   fallback: LimitScheduleMode,
 ): LimitScheduleMode {
   return value === "global" || value === "custom" || value === "always"
+    ? value
+    : fallback;
+}
+
+function sanitizeAccessBlockScheduleMode(
+  value: unknown,
+  fallback: AccessBlockScheduleMode,
+): AccessBlockScheduleMode {
+  return value === "global" || value === "custom" || value === "never"
     ? value
     : fallback;
 }

--- a/lib/page-interaction-guard.ts
+++ b/lib/page-interaction-guard.ts
@@ -16,7 +16,10 @@ export class PageInteractionGuard {
   private active = false;
   private owner: number | undefined;
 
-  constructor(private readonly target: EventTarget = window) {}
+  constructor(
+    private readonly target: EventTarget = window,
+    private readonly allowInteraction?: (event: Event) => boolean,
+  ) {}
 
   engage(owner: number): void {
     this.owner = owner;
@@ -50,6 +53,7 @@ export class PageInteractionGuard {
   }
 
   private readonly blockInteraction = (event: Event): void => {
+    if (this.allowInteraction?.(event)) return;
     event.preventDefault();
     event.stopImmediatePropagation();
   };

--- a/tests/limit-schedule.test.ts
+++ b/tests/limit-schedule.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   areLimitsActive,
+  isAccessBlocked,
   isWithinWeeklySchedule,
 } from "../lib/limit-schedule";
 import {
@@ -110,5 +111,64 @@ describe("weekly limit schedules", () => {
         new Date(2026, 7, 11, 3, 0),
       ),
     ).toBe(true);
+  });
+
+  it("blocks every route during inherited global blocked hours", () => {
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      accessBlockSchedule: {
+        ...DEFAULT_SETTINGS.accessBlockSchedule,
+        globalEnabled: true,
+        global: mondayOnly("22:00", "07:00"),
+      },
+    };
+
+    expect(
+      isAccessBlocked(settings, "reddit", new Date(2026, 7, 10, 23, 0)),
+    ).toBe(true);
+    expect(
+      isAccessBlocked(settings, "reddit", new Date(2026, 7, 11, 6, 59)),
+    ).toBe(true);
+    expect(
+      isAccessBlocked(settings, "reddit", new Date(2026, 7, 11, 7, 0)),
+    ).toBe(false);
+  });
+
+  it("supports custom and never-block modes per network", () => {
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      accessBlockSchedule: {
+        ...DEFAULT_SETTINGS.accessBlockSchedule,
+        globalEnabled: true,
+        global: mondayOnly("09:00", "17:00"),
+        modeByPlatform: {
+          reddit: "global" as const,
+          x: "custom" as const,
+          instagram: "never" as const,
+          youtube: "global" as const,
+        },
+        byPlatform: {
+          ...DEFAULT_SETTINGS.accessBlockSchedule.byPlatform,
+          x: mondayOnly("18:00", "21:00"),
+        },
+      },
+    };
+
+    const mondayAtTen = new Date(2026, 7, 10, 10, 0);
+    const mondayAtNineteen = new Date(2026, 7, 10, 19, 0);
+    expect(isAccessBlocked(settings, "reddit", mondayAtTen)).toBe(true);
+    expect(isAccessBlocked(settings, "x", mondayAtTen)).toBe(false);
+    expect(isAccessBlocked(settings, "x", mondayAtNineteen)).toBe(true);
+    expect(isAccessBlocked(settings, "instagram", mondayAtTen)).toBe(false);
+  });
+
+  it("does not block inherited networks when global blocking is off", () => {
+    expect(
+      isAccessBlocked(
+        DEFAULT_SETTINGS,
+        "youtube",
+        new Date(2026, 7, 10, 23, 0),
+      ),
+    ).toBe(false);
   });
 });

--- a/tests/models.test.ts
+++ b/tests/models.test.ts
@@ -131,6 +131,49 @@ describe("settings", () => {
     );
   });
 
+  it("sanitizes access-block schedules with blocking disabled by default", () => {
+    const settings = sanitizeSettings({
+      accessBlockSchedule: {
+        globalEnabled: true,
+        global: {
+          startTime: "24:00",
+          endTime: "06:30",
+          days: { sunday: false },
+        },
+        modeByPlatform: {
+          reddit: "custom",
+          x: "invalid",
+          instagram: "never",
+        },
+        byPlatform: {
+          reddit: {
+            startTime: "21:15",
+            endTime: "07:45",
+            days: { friday: false },
+          },
+        },
+      },
+    });
+
+    expect(settings.accessBlockSchedule.globalEnabled).toBe(true);
+    expect(settings.accessBlockSchedule.global.startTime).toBe("22:00");
+    expect(settings.accessBlockSchedule.global.endTime).toBe("06:30");
+    expect(settings.accessBlockSchedule.global.days.sunday).toBe(false);
+    expect(settings.accessBlockSchedule.global.days.monday).toBe(true);
+    expect(settings.accessBlockSchedule.modeByPlatform.reddit).toBe("custom");
+    expect(settings.accessBlockSchedule.modeByPlatform.x).toBe("global");
+    expect(settings.accessBlockSchedule.modeByPlatform.instagram).toBe(
+      "never",
+    );
+    expect(settings.accessBlockSchedule.byPlatform.reddit.startTime).toBe(
+      "21:15",
+    );
+    expect(settings.accessBlockSchedule.byPlatform.reddit.days.friday).toBe(
+      false,
+    );
+    expect(sanitizeSettings({}).accessBlockSchedule.globalEnabled).toBe(false);
+  });
+
   it("drops legacy post-limit and friction-mode settings", () => {
     const settings = sanitizeSettings({
       mode: "strict",

--- a/tests/page-interaction-guard.test.ts
+++ b/tests/page-interaction-guard.test.ts
@@ -32,4 +32,21 @@ describe("page interaction guard", () => {
 
     expect(event.defaultPrevented).toBe(false);
   });
+
+  it("allows explicitly trusted extension interactions while active", () => {
+    const target = new EventTarget();
+    const guard = new PageInteractionGuard(
+      target,
+      (event) => event.type === "click",
+    );
+    guard.engage(1);
+
+    const allowedClick = new Event("click", { cancelable: true });
+    const blockedWheel = new Event("wheel", { cancelable: true });
+    target.dispatchEvent(allowedClick);
+    target.dispatchEvent(blockedWheel);
+
+    expect(allowedClick.defaultPrevented).toBe(false);
+    expect(blockedWheel.defaultPrevented).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- add independent full-access blocked hours with a global default and per-network global, custom or never-block modes
- block every route on a scheduled network, including feeds, posts or videos, profiles, messages and site settings
- make blocked windows override limit schedules, active sessions, daily timers and feed controllers
- keep the floating usage counter translucent and pointer-transparent so underlying content remains clickable
- reorganize schedule controls so limit hours and blocked hours are visibly distinct

## Behavior

Blocked hours are disabled by default for backward compatibility. The default configured window is 22:00–07:00 and supports selected weekdays, overnight ranges and full-day ranges. Crossing a boundary or changing settings applies immediately without reloading.

When blocking starts, any active planned session is persisted, stopped and cleared. The blocking screen offers only leaving the network or opening Dopamine Fast settings; there is no snooze or temporary unlock.

The interaction guard remains active behind the blocking screen, while its two extension controls stay usable and keyboard focus remains trapped inside the dialog.

## Validation

- `npm run validate` — 66 tests, typecheck, Firefox build and Chrome build
- `npm run zip` — Firefox and Chrome packages generated
- `git diff --check`
- no duplicate options-page element IDs

## Manual testing

- [ ] Verify global, custom and never-block modes on all four supported networks.
- [ ] Verify entering and leaving normal, overnight and full-day blocked windows without a reload.
- [ ] Verify feeds, detail pages, profiles, messages and site settings cannot be interacted with while blocked.
- [ ] Verify Leave and View blocking schedule remain keyboard/touch accessible.
- [ ] Verify the floating counter is readable but clicks pass through it on Firefox Android and Chromium.

## Privacy and permissions

No new permissions, remote data handling, analytics or host matches are introduced. All schedules remain in extension-local storage.